### PR TITLE
Add FakeTPCreatorHeartbeatMaker to trigger chain

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -436,10 +436,6 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
         if app.name=="__app":
             app.name=name
 
-    # TODO PAR 2021-12-11 Fix up the indexing here. There's one output
-    # endpoint per link in the ru apps (maybe there should just be one
-    # per app?), and all the TPSets from one RU go to the same TA
-    # input in the trigger app
     if enable_software_tpg:
         for ruidx,ru_app_name in enumerate(ru_app_names):
             ru_config = ru_configs[ruidx]
@@ -456,7 +452,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
                                       msg_module_name="TPSetNQ",
                                       topics=["TPSets"],
                                       receivers=[f"trigger.tpsets_into_buffer_ru{ruidx}_link{link}",
-                                                 f"trigger.tpsets_into_chain_apa{apa_idx}"])
+                                                 f"trigger.tpsets_into_chain_ru{ruidx}_link{link}"])
                     })
 
 


### PR DESCRIPTION
This PR adds a `FakeTPCreatorHeartbeatMaker` plugin to each TP input link of the trigger app. The heartbeats allow the trigger system to advance even when no input is received.