### PR TITLE
Modified the dataflow_gen to fix up the HDF5 file layout for TP fragments

### DIFF
--- a/python/daqconf/apps/dataflow_gen.py
+++ b/python/daqconf/apps/dataflow_gen.py
@@ -104,12 +104,8 @@ def get_dataflow_app(RU_CONFIG=[],
                                                         detector_group_name="PDS"),
                                         h5fl.PathParams(detector_group_type="NDLArTPC",
                                                         detector_group_name="NDLArTPC"),
-                                        h5fl.PathParams(detector_group_type="Trigger",
-                                                        detector_group_name="Trigger"),
-                                        h5fl.PathParams(detector_group_type="TPC_TP",
-                                                        detector_group_name="TPC",
-                                                        region_name_prefix="TP_APA",
-                                                        element_name_prefix="Link")])))))]
+                                        h5fl.PathParams(detector_group_type="DataSelection",
+                                                        detector_group_name="Trigger")])))))]
 
     if TPSET_WRITING_ENABLED:
         for idx in range(len(RU_CONFIG)):


### PR DESCRIPTION
Here is a possible confgen command to test this change:

```
daqconf_multiru_gen --host-ru localhost --host-ru localhost --host-df localhost --host-df localhost -d $PWD/frames.bin -o . -s 10 -n 2 --enable-software-tpg mdapp_2x2_swtpg
```

With this change, I see Trigger TP fragments in the HDF5 file, and I see all TPC-related fragments have an HDF5 group structure of TPC/APA.../Link..
