### PR TITLE
Don't request TPs from readout to go in TriggerRecords

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -328,8 +328,24 @@ def get_readout_app(RU_CONFIG=[],
                                          fragments_out = f"datahandler_{idx}.fragment_queue")
 
             # Add fragment producers for TPC TPs. Make sure the element index doesn't overlap with the ones for raw data
+            #
+            # NB We decided not to request TPs from readout for the
+            # 2.10 release. It would be nice to achieve this by just
+            # not adding fragment producers for the relevant links
+            # here, but then the necessary input and output queues for
+            # the DataLinkHandler modules are not created, so we can't
+            # init. So instead we do it this roundabout way: the
+            # fragment producers are all created, and then they are
+            # eventually removed from the MLT's list of links to
+            # request data from. That removal is done in
+            # daqconf_multiru_gen, which relies on a convention that
+            # TP links have element value > 1000.
+            #
+            # This situation should change after release 2.10, when
+            # real firmware TPs become available
             if SOFTWARE_TPG_ENABLED:
-                mgraph.add_fragment_producer(region = RU_CONFIG[RUIDX]["region_id"], element = idx + total_link_count, system = SYSTEM_TYPE,
+                assert total_link_count < 1000
+                mgraph.add_fragment_producer(region = RU_CONFIG[RUIDX]["region_id"], element = idx + 1000, system = SYSTEM_TYPE,
                                              requests_in   = f"tp_datahandler_{idx}.data_requests_0",
                                              fragments_out = f"tp_datahandler_{idx}.fragment_queue")
 

--- a/python/daqconf/core/fragment_producers.py
+++ b/python/daqconf/core/fragment_producers.py
@@ -55,6 +55,20 @@ def set_mlt_links(the_system, mlt_app_name="trigger", verbose=False):
                                                    dfo_connection=old_mlt_conf.dfo_connection, 
                                                    dfo_busy_connection=old_mlt_conf.dfo_busy_connection))
 
+def remove_mlt_link(the_system, geoid, mlt_app_name="trigger"):
+    """
+    Remove the given geoid (which should be a dict with keys "system", "region", "element") from the list of links to request data from in the MLT.
+    """
+    mgraph = the_system.apps[mlt_app_name].modulegraph
+    old_mlt_conf = mgraph.get_module("mlt").conf
+    mlt_links = old_mlt_conf.links
+    if geoid not in mlt_links:
+        raise ValueError(f"GeoID {geoid} not in MLT links list")
+    mlt_links.remove(geoid)
+    mgraph.reset_module_conf("mlt", mlt.ConfParams(links=mlt_links, 
+                                                   dfo_connection=old_mlt_conf.dfo_connection, 
+                                                   dfo_busy_connection=old_mlt_conf.dfo_busy_connection))
+    
 def connect_fragment_producers(app_name, the_system, verbose=False):
     """Connect the data request and fragment sending queues from all of
        the fragment producers in the app with name `app_name` to the

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -30,6 +30,7 @@ import moo.otypes
 moo.otypes.load_types('networkmanager/nwmgr.jsonnet')
 import dunedaq.networkmanager.nwmgr as nwmgr
 
+
 import click
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -531,7 +532,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
     
     #     console.log(f"MDAapp config generated in {json_dir}")
     from appfwk.conf_utils import add_network, make_app_command_data
-    from daqconf.core.fragment_producers import  connect_all_fragment_producers, set_mlt_links
+    from daqconf.core.fragment_producers import  connect_all_fragment_producers, set_mlt_links, remove_mlt_link
 
     if debug:
         the_system.export("system_no_frag_prod_connection.dot")
@@ -541,9 +542,33 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
     # console.log("After connecting fragment producers, the_system.app_connections:", the_system.app_connections)
 
     set_mlt_links(the_system, "trigger", verbose=debug)
+
     mlt_links=the_system.apps["trigger"].modulegraph.get_module("mlt").conf.links
     if debug:
         console.log(f"After set_mlt_links, mlt_links is {mlt_links}")
+
+    # HACK HACK HACK P. Rodrigues 2022-03-04 We decided not to request
+    # TPs from readout for the 2.10 release. It would be nice to
+    # achieve this by just not adding fragment producers for the
+    # relevant links in readout_gen.py, but then the necessary input
+    # and output queues for the DataLinkHandler modules are not
+    # created. So instead we do it this roundabout way: the fragment
+    # producers are all created, they are added to the MLT's list of
+    # links to read out from (in set_mlt_links above), and then
+    # removed here. We rely on a convention that TP links have element
+    # value > 1000.
+    #
+    # This code should be removed after 2.10, when we will have
+    # decided how to handle raw TP data as fragments
+    for link in mlt_links:
+        if link["system"] == system_type and link["element"] > 1000:
+            remove_mlt_link(the_system, link)
+
+    mlt_links=the_system.apps["trigger"].modulegraph.get_module("mlt").conf.links
+    if debug:
+        console.log(f"After remove_mlt_links, mlt_links is {mlt_links}")
+    # END HACK
+        
     add_network("trigger", the_system, verbose=debug)
     add_network("dfo", the_system, verbose=debug)
 

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -556,12 +556,12 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
     # producers are all created, they are added to the MLT's list of
     # links to read out from (in set_mlt_links above), and then
     # removed here. We rely on a convention that TP links have element
-    # value > 1000.
+    # value >= 1000.
     #
     # This code should be removed after 2.10, when we will have
     # decided how to handle raw TP data as fragments
     for link in mlt_links:
-        if link["system"] == system_type and link["element"] > 1000:
+        if link["system"] == system_type and link["element"] >= 1000:
             remove_mlt_link(the_system, link)
 
     mlt_links=the_system.apps["trigger"].modulegraph.get_module("mlt").conf.links


### PR DESCRIPTION
This is a hack for 2.10, until we decide how to handle raw firmware
TPs and data selection TPs in the HDF5 output file.

The implementation is hacky, and described in comments in `daqconf_multiru_gen` and `readout_gen.py`. But it will all go away right after 2.10, so I feel no shame