### PR TITLE
Use CPUPinner module from `readoutmodules`

### DIFF
--- a/python/daqconf/apps/cpupin.json
+++ b/python/daqconf/apps/cpupin.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "fakeprod-0",
+        "cpu_set": [0]
+    },
+    {
+        "name": "postprocess-0-0",
+        "cpu_set": [2]
+    },
+    {
+        "name": "ind-hits-0-0",
+        "cpu_set": [4]
+    },
+    {
+        "name": "consumer-0",
+        "cpu_set": [24]
+    }
+]

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -17,6 +17,7 @@ moo.otypes.load_types('nwqueueadapters/networkobjectsender.jsonnet')
 moo.otypes.load_types('flxlibs/felixcardreader.jsonnet')
 moo.otypes.load_types('readoutlibs/sourceemulatorconfig.jsonnet')
 moo.otypes.load_types('readoutlibs/readoutconfig.jsonnet')
+moo.otypes.load_types('readoutmodules/cpupinner.jsonnet')
 moo.otypes.load_types('lbrulibs/pacmancardreader.jsonnet')
 moo.otypes.load_types('dfmodules/fakedataprod.jsonnet')
 moo.otypes.load_types('networkmanager/nwmgr.jsonnet')
@@ -31,6 +32,7 @@ import dunedaq.nwqueueadapters.queuetonetwork as qton
 import dunedaq.nwqueueadapters.networkobjectreceiver as nor
 import dunedaq.nwqueueadapters.networkobjectsender as nos
 import dunedaq.readoutlibs.sourceemulatorconfig as sec
+import dunedaq.readoutmodules.cpupinner as pin
 import dunedaq.flxlibs.felixcardreader as flxcr
 import dunedaq.readoutlibs.readoutconfig as rconf
 import dunedaq.lbrulibs.pacmancardreader as pcr
@@ -86,6 +88,16 @@ def get_readout_app(RU_CONFIG=[],
     if DEBUG: print(f"ReadoutApp.__init__ with RUIDX={RUIDX}, MIN_LINK={MIN_LINK}, MAX_LINK={MAX_LINK}")
     modules = []
 
+    modules += [DAQModule(name = "cpupinner",
+                          plugin = "CPUPinner",
+                          connections = {},
+                          conf = pin.Conf(thread_confs = pin.ThreadConfs([
+                              pin.ThreadConf(name = "fakeprod-0",      cpu_set = [0]),
+                              pin.ThreadConf(name = "postprocess-0-0", cpu_set = [2]),
+                              pin.ThreadConf(name = "ind-hits-0-0",    cpu_set = [4]),
+                              pin.ThreadConf(name = "consumer-0",      cpu_set = [24]),
+                          ])))]
+    
     total_link_count = 0
     for ru in range(len(RU_CONFIG)):
         if RU_CONFIG[ru]['region_id'] == RU_CONFIG[RUIDX]['region_id']:

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -59,6 +59,7 @@ import click
 @click.option('--host-tprtc', default='localhost', help='Host to run the timing partition controller app on')
 @click.option('--region-id', multiple=True, default=[0], help="Define the Region IDs for the RUs. If only specified once, will apply to all RUs.")
 @click.option('--latency-buffer-size', default=499968, help="Size of the latency buffers (in number of elements)")
+@click.option('--readout-cpu-pin-file', type=click.Path(), default=None, help="File containing CPU pinning config for readout")
 # hsi readout options
 @click.option('--hsi-hw-connections-file', default="${TIMING_SHARE}/config/etc/connections.xml", help='Real timing hardware only: path to hardware connections file')
 @click.option('--hsi-device-name', default="", help='Real HSI hardware only: device name of HSI hw')
@@ -120,7 +121,7 @@ import click
 @click.argument('json_dir', type=click.Path())
 
 def cli(global_partition_name, host_global, port_global, partition_name, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, clock_speed_hz, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
-        token_count, data_file, output_path, disable_trace, use_felix, use_ssp, host_df, host_dfo, host_ru, host_trigger, host_hsi, host_tpw, host_tprtc, region_id, latency_buffer_size,
+        token_count, data_file, output_path, disable_trace, use_felix, use_ssp, host_df, host_dfo, host_ru, host_trigger, host_hsi, host_tpw, host_tprtc, region_id, latency_buffer_size, readout_cpu_pin_file,
         hsi_hw_connections_file, hsi_device_name, hsi_readout_period, control_hsi_hw, hsi_endpoint_address, hsi_endpoint_partition, hsi_re_mask, hsi_fe_mask, hsi_inv_mask, hsi_source,
         use_hsi_hw, hsi_device_id, mean_hsi_signal_multiplicity, hsi_signal_emulation_mode, enabled_hsi_signals,
         ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config, hsi_trigger_type_passthrough,
@@ -406,6 +407,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
                                               USE_FAKE_DATA_PRODUCERS = use_fake_data_producers,
                                               HOST=host,
                                               LATENCY_BUFFER_SIZE=latency_buffer_size,
+                                              CPU_PIN_FILE = readout_cpu_pin_file,
                                               DEBUG=debug)
         
         if debug:


### PR DESCRIPTION
This PR uses the `CPUPinner` DAQModule introduced by https://github.com/DUNE-DAQ/readoutmodules/pull/4 in config. This is all a temporary solution for the spring 2022 VD coldbox tests. 

We pass a json file describing the pinning config for readout via the `--readout-cpu-pin-file` command line argument. When this argument is passed, a `CPUPinner` module is created in the readout process. The module is created in every readout process, which is not correct for multiple readout processes, but there'll only be one readout process for the VD coldbox, so temporarily, this should be fine.

I've put an example CPU pinning json file in `daqconf/python/daqconf/apps/cpupin.json`, which is probably not the right place, but can move it later