### PR TITLE
Use the TPChannelFilter module

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -340,6 +340,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
         TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks,
         HSI_TRIGGER_TYPE_PASSTHROUGH = hsi_trigger_type_passthrough,
         PARTITION=partition_name,
+        CHANNEL_MAP_NAME = tpg_channel_map,
         HOST=host_trigger,
         DEBUG=debug)
 


### PR DESCRIPTION
This PR adds the use of the TPChannelFilter module to remove induction channel hits before sending TPSets downstream to the rest of the trigger chain.