### PR TITLE
Add CPU pinning configuration for np04-srv-030 with data from FELIX

### DIFF
--- a/python/daqconf/apps/cpupin-np04-srv-030-emudata.json
+++ b/python/daqconf/apps/cpupin-np04-srv-030-emudata.json
@@ -1,0 +1,140 @@
+[
+    {
+        "name": "flx-dma-0",
+        "cpu_set": [0]
+    },
+
+
+
+    {
+        "name": "ept-0-0-0",
+        "cpu_set": [2]
+    },
+    {
+        "name": "postprocess-0-0",
+        "cpu_set": [4]
+    },
+    {
+        "name": "ind-hits-0-0",
+        "cpu_set": [6]
+    },
+    {
+        "name": "consumer-0",
+        "cpu_set": [26]
+    },
+
+
+    {
+        "name": "ept-0-0-64",
+        "cpu_set": [10]
+    },
+    {
+        "name": "postprocess-0-1",
+        "cpu_set": [12]
+    },
+    {
+        "name": "ind-hits-0-1",
+        "cpu_set": [14]
+    },
+    {
+        "name": "consumer-1",
+        "cpu_set": [34]
+    },
+
+
+    {
+        "name": "ept-0-0-128",
+        "cpu_set": [16]
+    },
+    {
+        "name": "postprocess-0-2",
+        "cpu_set": [18]
+    },
+    {
+        "name": "ind-hits-0-2",
+        "cpu_set": [20]
+    },
+    {
+        "name": "consumer-2",
+        "cpu_set": [40]
+    },
+
+
+
+    {
+        "name": "ept-0-0-192",
+        "cpu_set": [22]
+    },
+    {
+        "name": "postprocess-0-3",
+        "cpu_set": [1]
+    },
+    {
+        "name": "ind-hits-0-3",
+        "cpu_set": [3]
+    },
+    {
+        "name": "consumer-3",
+        "cpu_set": [46]
+    },
+
+
+    
+    {
+        "name": "ept-0-0-256",
+        "cpu_set": [5]
+    },
+    {
+        "name": "postprocess-0-4",
+        "cpu_set": [7]
+    },
+    {
+        "name": "ind-hits-0-4",
+        "cpu_set": [9]
+    },
+    {
+        "name": "consumer-4",
+        "cpu_set": [29]
+    },
+
+
+    
+    {
+        "name": "ept-0-1-0",
+        "cpu_set": [11]
+    },
+    {
+        "name": "postprocess-0-5",
+        "cpu_set": [13]
+    },
+    {
+        "name": "ind-hits-0-5",
+        "cpu_set": [15]
+    },
+    {
+        "name": "consumer-5",
+        "cpu_set": [35]
+    },
+
+
+    
+    {
+        "name": "ept-0-1-64",
+        "cpu_set": [17]
+    },
+    {
+        "name": "postprocess-0-6",
+        "cpu_set": [19]
+    },
+    {
+        "name": "ind-hits-0-6",
+        "cpu_set": [21]
+    },
+    {
+        "name": "consumer-6",
+        "cpu_set": [41]
+    }
+
+
+
+]


### PR DESCRIPTION
This draft PR is just a placeholder so I can put the committed file somewhere other people can see it.

This file provides a CPU pinning configuration that can be passed to
daqconf_multiru_gen via the --readout-cpu-pin-file option, suitable
for use on np04-srv-030 with the VD coldbox. It's been tested with
emulated data from the FELIX card, and works with up to 7 links.

For each link, there are four threads: ept-0-X-Z, postprocess-0-X,
ind-hits-0-X and consumer-X. The general strategy is to keep all of
the threads on the same NUMA node, with the ept and consumer threads
sharing hyperthread sibling cores (since those two threads have the
lowest CPU usage). Link 3 is an exception: it's split between NUMA
nodes, with the ept and consumer threads on node 0 (even-numbered
cores) and the postprocess and ind-hits threads on node 1.