### PR TITLE
Allow DQM to run on different hosts

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -536,7 +536,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
 
         if enable_dqm:
             dqmidx = i % len(host_dqm)
-            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tr_df2dqm_{i}", topics=[], address=f"tcp://{{host_{dqm_df_app_names[i]}}}:{the_system.next_unassigned_port()}"))
+            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tr_df2dqm_{i}", topics=[], address=f"tcp://{{host_{dqm_df_app_names[dqmidx]}}}:{the_system.next_unassigned_port()}"))
     
     the_system.app_connections["hsi.hsievents"] = AppConnection(nwmgr_connection=f"{partition_name}.hsievents",
                                                                 topics=[],

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -58,7 +58,7 @@ import click
 @click.option('--host-hsi', default='localhost', help='Host to run the HSI app on')
 @click.option('--host-tpw', default='localhost', help='Host to run the TPWriter app on')
 @click.option('--host-tprtc', default='localhost', help='Host to run the timing partition controller app on')
-@click.option('--host-dqm', default='localhost', help='Host to run the DQM aps on')
+@click.option('--host-dqm', multiple=True, default=['localhost'], help='Host to run the DQM aps on')
 @click.option('--region-id', multiple=True, default=[0], help="Define the Region IDs for the RUs. If only specified once, will apply to all RUs.")
 @click.option('--latency-buffer-size', default=499968, help="Size of the latency buffers (in number of elements)")
 # hsi readout options
@@ -135,6 +135,9 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
 
     if exists(json_dir):
         raise RuntimeError(f"Directory {json_dir} already exists")
+
+    print(f'{host_dqm=}')
+    print(type(host_dqm))
 
     console.log("Loading dataflow config generator")
     from daqconf.apps.dataflow_gen import get_dataflow_app
@@ -250,8 +253,9 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
     dqm_app_names = [f"dqm{idx}_ru" for idx in range(len(host_ru))]
     
     for hostidx,ru_host in enumerate(ru_app_names):
+        dqmidx = hostidx % len(host_dqm)
         if enable_dqm:
-            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.fragx_dqm_{hostidx}", topics=[], address=f"tcp://{{host_{host_dqm[hostidx % len(host_dqm)]}}}:{the_system.next_unassigned_port()}"))
+            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.fragx_dqm_{hostidx}", topics=[], address=f"tcp://{{host_{dqm_app_names[hostidx]}}}:{the_system.next_unassigned_port()}"))
             # Create at most {number of df apps} endpoints
 
         the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.datareq_{hostidx}", topics=[], address=f"tcp://{{host_{ru_host}}}:{the_system.next_unassigned_port()}"))
@@ -435,7 +439,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
                 DQM_FOURIER_PARAMS=dqm_fourier_params,
                 DQM_FOURIERSUM_PARAMS=dqm_fouriersum_params,
                 PARTITION=partition_name,
-                HOST=host,
+                HOST=host_dqm[i % len(host_dqm)],
                 NUM_DF_APPS=len(host_df),
                 DEBUG=debug)
             if debug: console.log(f"{dqm_name} app: {the_system.apps[dqm_name]}")
@@ -489,7 +493,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
                 DQM_FOURIER_PARAMS=[0, 0, 0],
                 DQM_FOURIERSUM_PARAMS=[0, 0, 0],
                 PARTITION=partition_name,
-                HOST=host_ru[i%len(host_ru)],
+                HOST=host_dqm[i % len(host_dqm)],
                 MODE='df',
                 DF_RATE=dqm_df_rate,
                 DF_ALGS=dqm_df_algs,
@@ -534,7 +538,8 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
         the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.trmon_dqm2df_{i}", topics=[], address=f"tcp://{{host_{df_app_name}}}:{the_system.next_unassigned_port()}"))
 
         if enable_dqm:
-            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tr_df2dqm_{i}", topics=[], address=f"tcp://{{host_{host_dqm[i % len(host_dqm)]}}}:{the_system.next_unassigned_port()}"))
+            dqmidx = i % len(host_dqm)
+            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tr_df2dqm_{i}", topics=[], address=f"tcp://{{host_{dqm_df_app_names[i]}}}:{the_system.next_unassigned_port()}"))
     
     the_system.app_connections["hsi.hsievents"] = AppConnection(nwmgr_connection=f"{partition_name}.hsievents",
                                                                 topics=[],

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -58,6 +58,7 @@ import click
 @click.option('--host-hsi', default='localhost', help='Host to run the HSI app on')
 @click.option('--host-tpw', default='localhost', help='Host to run the TPWriter app on')
 @click.option('--host-tprtc', default='localhost', help='Host to run the timing partition controller app on')
+@click.option('--host-dqm', default='localhost', help='Host to run the DQM aps on')
 @click.option('--region-id', multiple=True, default=[0], help="Define the Region IDs for the RUs. If only specified once, will apply to all RUs.")
 @click.option('--latency-buffer-size', default=499968, help="Size of the latency buffers (in number of elements)")
 # hsi readout options
@@ -106,6 +107,7 @@ import click
 @click.option('--tpg-channel-map', type=click.Choice(["VDColdboxChannelMap", "ProtoDUNESP1ChannelMap"]), default="ProtoDUNESP1ChannelMap", help="Channel map for software TPG")
 @click.option('--enable-tpset-writing', is_flag=True, default=False, help="Enable the writing of TPs to disk (only works with --enable-software-tpg")
 @click.option('--use-fake-data-producers', is_flag=True, default=False, help="Use fake data producers that respond with empty fragments immediately instead of (fake) cards and DLHs")
+
 @click.option('--dqm-cmap', type=click.Choice(['HD', 'VD']), default='HD', help="Which channel map to use for DQM")
 @click.option('--dqm-rawdisplay-params', nargs=3, default=[60, 10, 50], help="Parameters that control the data sent for the raw display plot")
 @click.option('--dqm-meanrms-params', nargs=3, default=[10, 1, 100], help="Parameters that control the data sent for the mean/rms plot")
@@ -122,7 +124,7 @@ import click
 
 def cli(global_partition_name, host_global, port_global, partition_name, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, clock_speed_hz, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
         thread_pinning_file,
-        token_count, data_file, output_path, disable_trace, use_felix, use_ssp, host_df, host_dfo, host_ru, host_trigger, host_hsi, host_tpw, host_tprtc, region_id, latency_buffer_size,
+        token_count, data_file, output_path, disable_trace, use_felix, use_ssp, host_df, host_dfo, host_ru, host_trigger, host_hsi, host_tpw, host_tprtc, host_dqm, region_id, latency_buffer_size,
         hsi_hw_connections_file, hsi_device_name, hsi_readout_period, control_hsi_hw, hsi_endpoint_address, hsi_endpoint_partition, hsi_re_mask, hsi_fe_mask, hsi_inv_mask, hsi_source,
         use_hsi_hw, hsi_device_id, mean_hsi_signal_multiplicity, hsi_signal_emulation_mode, enabled_hsi_signals,
         ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config, hsi_trigger_type_passthrough,
@@ -155,7 +157,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
         console.log("Loading TPWriter config generator")
         from daqconf.apps.tpwriter_gen import get_tpwriter_app
 
-    console.log(f"Generating configs for hosts trigger={host_trigger} DFO={host_dfo} dataflow={host_df} readout={host_ru} hsi={host_hsi} dqm={host_ru}")
+    console.log(f"Generating configs for hosts trigger={host_trigger} DFO={host_dfo} dataflow={host_df} readout={host_ru} hsi={host_hsi} dqm={host_dqm}")
 
     the_system = System(partition_name, first_port=port_global)
    
@@ -249,7 +251,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
     
     for hostidx,ru_host in enumerate(ru_app_names):
         if enable_dqm:
-            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.fragx_dqm_{hostidx}", topics=[], address=f"tcp://{{host_{ru_host}}}:{the_system.next_unassigned_port()}"))
+            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.fragx_dqm_{hostidx}", topics=[], address=f"tcp://{{host_{host_dqm[hostidx % len(host_dqm)]}}}:{the_system.next_unassigned_port()}"))
             # Create at most {number of df apps} endpoints
 
         the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.datareq_{hostidx}", topics=[], address=f"tcp://{{host_{ru_host}}}:{the_system.next_unassigned_port()}"))
@@ -532,7 +534,7 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
         the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.trmon_dqm2df_{i}", topics=[], address=f"tcp://{{host_{df_app_name}}}:{the_system.next_unassigned_port()}"))
 
         if enable_dqm:
-            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tr_df2dqm_{i}", topics=[], address=f"tcp://{{host_{ru_app_names[i % len(ru_app_names)]}}}:{the_system.next_unassigned_port()}"))
+            the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tr_df2dqm_{i}", topics=[], address=f"tcp://{{host_{host_dqm[i % len(host_dqm)]}}}:{the_system.next_unassigned_port()}"))
     
     the_system.app_connections["hsi.hsievents"] = AppConnection(nwmgr_connection=f"{partition_name}.hsievents",
                                                                 topics=[],

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -136,9 +136,6 @@ def cli(global_partition_name, host_global, port_global, partition_name, number_
     if exists(json_dir):
         raise RuntimeError(f"Directory {json_dir} already exists")
 
-    print(f'{host_dqm=}')
-    print(type(host_dqm))
-
     console.log("Loading dataflow config generator")
     from daqconf.apps.dataflow_gen import get_dataflow_app
     if enable_dqm:


### PR DESCRIPTION
Adds the new parameter `--host-dqm`. There can be multiple hosts and DQM apps will be assigned in a round-robin fashion to the hosts (i.e. `dqm_ru0` and `dqm_df0` to the first host and so on, cycling over the hosts if the number is less than the number of DQM apps)

Tested on the following configurations, asumming I'm running in host A:

-  Without DQM (1 `dqm_ru` and 1 `dqm_df`)
-  1 RU with DQM in the same host (A)
-  1 RU host B with DQM in host B
-  1 RU in host A with DQM in host B
-  2 RUs in host A and 2 `dqm_ru` and 1 `dqm_df` in host B
- 2 RUs in host A and 2 `dqm_ru` and 2 `dqm_df` in host B (2 DF apps are needed for this)

All the `dqm_ru` and `dqm_df` were working fine so it's ready