### PR TITLE
Eflumerf/topo sort for endpoints

### DIFF
--- a/python/daqconf/apps/dfo_gen.py
+++ b/python/daqconf/apps/dfo_gen.py
@@ -51,8 +51,8 @@ def get_dfo_app(TOKEN_COUNT: int = 10,
                           conf = dfo.ConfParams(dataflow_applications=df_app_configs))]
     
     mgraph = ModuleGraph(modules)
-    mgraph.add_endpoint("td_to_dfo", "dfo.td_connection", Direction.IN)
-    mgraph.add_endpoint("triginh", "dfo.token_connection", Direction.IN)
+    mgraph.add_endpoint("td_to_dfo", "dfo.td_connection", Direction.IN, toposort=False)
+    mgraph.add_endpoint("triginh", "dfo.token_connection", Direction.IN, toposort=False)
     mgraph.add_endpoint("df_busy_signal", "dfo.busy_connection", Direction.OUT)
     for i in range(DF_COUNT):
         mgraph.add_endpoint(f"trigger_decision_{i}", f"dfo.trigger_{i}_connection", Direction.OUT)

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -265,13 +265,13 @@ def get_readout_app(RU_CONFIG=[],
             mgraph.add_fragment_producer(region = RU_CONFIG[RUIDX]["region_id"], element = idx, system = SYSTEM_TYPE,
                                          requests_in   = f"fakedataprod_{idx}.data_request_input_queue",
                                          fragments_out = f"fakedataprod_{idx}.fragment_queue")
-            mgraph.add_endpoint(f"timesync_ru{RUIDX}_{idx}", f"fakedataprod_{idx}.timesync_output",    Direction.OUT, ["Timesync"])
+            mgraph.add_endpoint(f"timesync_ru{RUIDX}_{idx}", f"fakedataprod_{idx}.timesync_output",    Direction.OUT, ["Timesync"], toposort=False)
         else:
             # Add fragment producers for raw data
             mgraph.add_fragment_producer(region = RU_CONFIG[RUIDX]["region_id"], element = idx, system = SYSTEM_TYPE,
                                          requests_in   = f"datahandler_{idx}.request_input",
                                          fragments_out = f"datahandler_{idx}.fragment_queue")
-            mgraph.add_endpoint(f"timesync_ru{RUIDX}_{idx}", f"datahandler_{idx}.timesync_output",    Direction.OUT, ["Timesync"])
+            mgraph.add_endpoint(f"timesync_ru{RUIDX}_{idx}", f"datahandler_{idx}.timesync_output",    Direction.OUT, ["Timesync"], toposort=False)
 
             # Add fragment producers for TPC TPs. Make sure the element index doesn't overlap with the ones for raw data
             #

--- a/python/daqconf/core/app.py
+++ b/python/daqconf/core/app.py
@@ -166,9 +166,9 @@ class ModuleGraph:
                 return True
         return False
 
-    def add_endpoint(self, external_name, internal_name, inout, topic=[]):
+    def add_endpoint(self, external_name, internal_name, inout, topic=[], toposort=True):
         if not self.has_endpoint(external_name, internal_name):
-            self.endpoints += [Endpoint(external_name, internal_name, inout, topic)]
+            self.endpoints += [Endpoint(external_name, internal_name, inout, topic=topic, toposort=toposort)]
 
     def add_external_connection(self, external_name, internal_name, inout, host, port, topic=[]):
         self.external_connections += [ExternalConnection(external_name, internal_name, inout, host, port, topic)]

--- a/python/daqconf/core/fragment_producers.py
+++ b/python/daqconf/core/fragment_producers.py
@@ -147,7 +147,7 @@ def connect_fragment_producers(app_name, the_system, verbose=False):
         app.modulegraph.add_endpoint(fragment_connection_name, None, Direction.OUT)
         df_mgraph = df_app.modulegraph
         df_mgraph.add_endpoint(fragment_connection_name, "trb.data_fragment_all", Direction.IN)            
-        df_mgraph.add_endpoint(request_connection_name, f"trb.request_output_{app_name}", Direction.OUT)
+        df_mgraph.add_endpoint(request_connection_name, f"trb.request_output_{app_name}", Direction.OUT, toposort=False)
 
         # Add the new geoid-to-connections map to the
         # TriggerRecordBuilder.

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -8,7 +8,6 @@ import rich.traceback
 from rich.console import Console
 from os.path import exists, join
 from daqconf.core.system import System
-from daqconf.core.conf_utils import AppConnection
 from daqconf.core.metadata import write_metadata_file
 
 # Add -h as default help option
@@ -498,7 +497,7 @@ def cli(timing_partition_name, host_timing, port_timing, number_of_data_producer
 
     # Make boot.json config
     from daqconf.core.conf_utils import make_system_command_datas,generate_boot, write_json_files
-    system_command_datas = make_system_command_datas(the_system)
+    system_command_datas = make_system_command_datas(the_system, verbose=debug)
     # Override the default boot.json with the one from minidaqapp
     boot = generate_boot(the_system.apps,
                          ers_settings=ers_settings, info_svc_uri=info_svc_uri,


### PR DESCRIPTION
Phil noticed that `make_app_deps` in `conf_utils.py` was no longer functioning correctly, and we were not getting correct start/stop orders as a result.

This PR adds the ability to specify on either end of an endpoint that it should not be used for topological sorting, and for `make_app_deps` to use `System.make_digraph` so that system graph creation is always done in only one place.