### PR TITLE
Change polarity of toposort parameter to add_endpoint so that endpoints

### DIFF
--- a/python/daqconf/apps/dataflow_gen.py
+++ b/python/daqconf/apps/dataflow_gen.py
@@ -95,7 +95,7 @@ def get_dataflow_app(HOSTIDX=0,
 
     mgraph.connect_modules("trb.trigger_record_output", "datawriter.trigger_record_input", "trigger_records")
     mgraph.add_endpoint(f"trigger_decision_{HOSTIDX}", "trb.trigger_decision_input", Direction.IN)
-    mgraph.add_endpoint("triginh", "datawriter.token_output", Direction.OUT)
+    mgraph.add_endpoint("triginh", "datawriter.token_output", Direction.OUT, toposort=True)
     if HAS_DQM:
         mgraph.add_endpoint(f"trmon_dqm2df_{HOSTIDX}", "trb.mon_connection", Direction.IN)
         mgraph.add_endpoint(f"tr_df2dqm_{HOSTIDX}", None, Direction.OUT)

--- a/python/daqconf/apps/dfo_gen.py
+++ b/python/daqconf/apps/dfo_gen.py
@@ -51,11 +51,11 @@ def get_dfo_app(TOKEN_COUNT: int = 10,
                           conf = dfo.ConfParams(dataflow_applications=df_app_configs))]
     
     mgraph = ModuleGraph(modules)
-    mgraph.add_endpoint("td_to_dfo", "dfo.td_connection", Direction.IN, toposort=False)
+    mgraph.add_endpoint("td_to_dfo", "dfo.td_connection", Direction.IN)
     mgraph.add_endpoint("triginh", "dfo.token_connection", Direction.IN)
-    mgraph.add_endpoint("df_busy_signal", "dfo.busy_connection", Direction.OUT, toposort=False)
+    mgraph.add_endpoint("df_busy_signal", "dfo.busy_connection", Direction.OUT)
     for i in range(DF_COUNT):
-        mgraph.add_endpoint(f"trigger_decision_{i}", f"dfo.trigger_{i}_connection", Direction.OUT, toposort=False)
+        mgraph.add_endpoint(f"trigger_decision_{i}", f"dfo.trigger_{i}_connection", Direction.OUT)
 
     dfo_app = App(modulegraph=mgraph, host=HOST, name='DFOApp')
     

--- a/python/daqconf/apps/dqm_gen.py
+++ b/python/daqconf/apps/dqm_gen.py
@@ -126,8 +126,8 @@ def get_dqm_app(RU_CONFIG=[],
         mgraph.connect_modules("dqmprocessor.trigger_decision_input_queue", "trb_dqm.trigger_decision_input", 'trigger_decision_q_dqm')
         mgraph.connect_modules('trb_dqm.trigger_record_output', 'dqmprocessor.trigger_record_dqm_processor', 'trigger_record_q_dqm', toposort=False)  
     elif DQMIDX < NUM_DF_APPS:
-        mgraph.add_endpoint(f'trmon_dqm2df_{DQMIDX}', None, Direction.OUT, toposort=False)
-        mgraph.add_endpoint(f"tr_df2dqm_{DQMIDX}", None, Direction.IN)
+        mgraph.add_endpoint(f'trmon_dqm2df_{DQMIDX}', None, Direction.OUT)
+        mgraph.add_endpoint(f"tr_df2dqm_{DQMIDX}", None, Direction.IN, toposort=True)
     
     dqm_app = App(mgraph, host=HOST)
 

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -295,9 +295,9 @@ def get_trigger_app(SOFTWARE_TPG_ENABLED: bool = False,
             mgraph.connect_modules(f'tasettee_region_{region_id}.output1', f'tazipper.input', "tas_to_tazipper",      size_hint=1000)
             mgraph.connect_modules(f'tasettee_region_{region_id}.output2', f'ta_buf_region_{region_id}.taset_source', size_hint=1000)
     
-    mgraph.add_endpoint("hsievents", None, Direction.IN)
+    mgraph.add_endpoint("hsievents", None, Direction.IN, toposort=True)
     mgraph.add_endpoint("td_to_dfo", None, Direction.OUT)
-    mgraph.add_endpoint("df_busy_signal", None, Direction.IN)
+    mgraph.add_endpoint("df_busy_signal", None, Direction.IN, toposort=True)
 
     mgraph.add_fragment_producer(region=TC_REGION_ID, element=TC_ELEMENT_ID, system="DataSelection",
                                  requests_in="tc_buf.data_request_source",

--- a/python/daqconf/core/app.py
+++ b/python/daqconf/core/app.py
@@ -166,7 +166,7 @@ class ModuleGraph:
                 return True
         return False
 
-    def add_endpoint(self, external_name, internal_name, inout, topic=[], toposort=True):
+    def add_endpoint(self, external_name, internal_name, inout, topic=[], toposort=False):
         if not self.has_endpoint(external_name, internal_name):
             self.endpoints += [Endpoint(external_name, internal_name, inout, topic=topic, toposort=toposort)]
 

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -51,7 +51,7 @@ class Endpoint:
     #         self.__init_with_nwmgr(**kwargs)
     #     else:
     #         self.__init_with_external_name(**kwargs)
-    def __init__(self, external_name, internal_name, direction, topic=[], size_hint=1000, toposort=True):
+    def __init__(self, external_name, internal_name, direction, topic=[], size_hint=1000, toposort=False):
         self.external_name = external_name
         self.internal_name = internal_name
         self.direction = direction
@@ -157,7 +157,7 @@ def make_module_deps(app, system_connections, verbose=False):
     return deps
 
 
-def make_app_deps(the_system, verbose=False):
+def make_app_deps(the_system, forced_deps=[], verbose=False):
     """
     Produce a dictionary giving
     the dependencies between a set of applications, given their connections.
@@ -166,6 +166,10 @@ def make_app_deps(the_system, verbose=False):
     """
 
     deps = the_system.make_digraph(for_toposort=True)
+
+    for from_app,to_app in forced_deps:
+        deps.add_edge(from_app, to_app, label="FORCED DEPENDENCY", color="green")
+
     if verbose:
         console.log("Writing app deps to make_app_deps.dot")
         nx.drawing.nx_pydot.write_dot(deps, "make_app_deps.dot")
@@ -584,13 +588,12 @@ def make_app_json(app_name, app_command_data, data_dir, verbose=False):
         with open(f'{join(data_dir, app_name)}_{c}.json', 'w') as f:
             json.dump(app_command_data[c].pod(), f, indent=4, sort_keys=True)
 
-def make_system_command_datas(the_system, verbose=False):
+def make_system_command_datas(the_system, forced_deps=[], verbose=False):
     """Generate the dictionary of commands and their data for the entire system"""
 
     if the_system.app_start_order is None:
-        app_deps = make_app_deps(the_system, verbose)
-        # Start should go from downstream to upstream, so we need to reverse the sort (graph is directed from upstream to downstream)
-        the_system.app_start_order = list(nx.algorithms.dag.topological_sort(app_deps))[::-1]
+        app_deps = make_app_deps(the_system, forced_deps, verbose)
+        the_system.app_start_order = list(nx.algorithms.dag.topological_sort(app_deps))
 
     system_command_datas=dict()
 

--- a/python/daqconf/core/fragment_producers.py
+++ b/python/daqconf/core/fragment_producers.py
@@ -147,7 +147,7 @@ def connect_fragment_producers(app_name, the_system, verbose=False):
         app.modulegraph.add_endpoint(fragment_connection_name, None, Direction.OUT)
         df_mgraph = df_app.modulegraph
         df_mgraph.add_endpoint(fragment_connection_name, "trb.data_fragment_all", Direction.IN)            
-        df_mgraph.add_endpoint(request_connection_name, f"trb.request_output_{app_name}", Direction.OUT, toposort=False)
+        df_mgraph.add_endpoint(request_connection_name, f"trb.request_output_{app_name}", Direction.OUT)
 
         # Add the new geoid-to-connections map to the
         # TriggerRecordBuilder.
@@ -164,8 +164,8 @@ def connect_fragment_producers(app_name, the_system, verbose=False):
         fragment_connection_name = f"fragments_to_{dqm_name}"
         app.modulegraph.add_endpoint(fragment_connection_name, None, Direction.OUT)
         dqm_mgraph = dqm_app.modulegraph
-        dqm_mgraph.add_endpoint(fragment_connection_name, "trb_dqm.data_fragment_all", Direction.IN)            
-        dqm_mgraph.add_endpoint(request_connection_name, f"trb_dqm.request_output_{app_name}", Direction.OUT, toposort=False)
+        dqm_mgraph.add_endpoint(fragment_connection_name, "trb_dqm.data_fragment_all", Direction.IN, toposort=True)            
+        dqm_mgraph.add_endpoint(request_connection_name, f"trb_dqm.request_output_{app_name}", Direction.OUT)
 
         # Add the new geoid-to-connections map to the
         # TriggerRecordBuilder.

--- a/python/daqconf/core/system.py
+++ b/python/daqconf/core/system.py
@@ -56,7 +56,7 @@ class System:
                             if to_ep.direction == Direction.IN:
                                 if from_ep.external_name == to_ep.external_name:
                                     color="red"
-                                    if from_ep.toposort and to_ep.toposort:
+                                    if from_ep.toposort or to_ep.toposort:
                                         color="blue"
                                     elif for_toposort:
                                         continue

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -522,7 +522,15 @@ def cli(timing_partition_name, host_timing, port_timing, number_of_data_producer
 
     # Make boot.json config
     from daqconf.core.conf_utils import make_system_command_datas,generate_boot, write_json_files
-    system_command_datas = make_system_command_datas(the_system, verbose=debug)
+
+    # HACK: Make sure RUs start after trigger
+    forced_deps = []
+    
+    for i,host in enumerate(host_ru):
+        ru_name = ru_app_names[i]
+        forced_deps.append(['trigger', ru_name])
+
+    system_command_datas = make_system_command_datas(the_system, forced_deps, verbose=debug)
     # Override the default boot.json with the one from minidaqapp
     boot = generate_boot(the_system.apps,
                          ers_settings=ers_settings, info_svc_uri=info_svc_uri,


### PR DESCRIPTION
must be explicitly marked as participating in sorting. Add forced_deps
parameter to help resolve ordering conflicts.

Reorder start so that DQM is started after associated apps, while
maintaining trigger start after dataflow.