### PR TITLE
Allow control of the base command port value from commandline

### DIFF
--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -478,7 +478,7 @@ def make_unique_name(base, module_list):
 
     return f"{base}_{suffix}"
 
-def generate_boot(apps: list, ers_settings=None, info_svc_uri="file://info_${APP_ID}_${APP_PORT}.json",
+def generate_boot(apps: list, base_command_port: int=3333, ers_settings=None, info_svc_uri="file://info_${APP_ID}_${APP_PORT}.json",
                   disable_trace=False, use_kafka=False, verbose=False, extra_env_vars=dict()) -> dict:
     """Generate the dictionary that will become the boot.json file"""
 
@@ -524,10 +524,9 @@ def generate_boot(apps: list, ers_settings=None, info_svc_uri="file://info_${APP
         }
     }
 
-    first_port = 3333
     ports = {}
     for i, name in enumerate(apps.keys()):
-        ports[name] = first_port + i
+        ports[name] = base_command_port + i
 
     boot = {
         "env": {

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -30,6 +30,7 @@ import click
 @click.option('--timing-partition-name', default="timing", help="Name of the global partition to use, for ERS and OPMON and timing commands")
 @click.option('--host-timing', default='np04-srv-012.cern.ch', help='Host to run the (global) timing hardware interface app on')
 @click.option('--port-timing', default=12345, help='Port to host running the (global) timing hardware interface app on')
+@click.option('--base-command-port', type=int, default=3333, help="Base port of application command endpoints")
 @click.option('-n', '--number-of-data-producers', default=2, help="Number of links to use for each readout application")
 @click.option('-e', '--emulator-mode', is_flag=True, help="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps.")
 @click.option('--thread-pinning-file', default=None, type=click.Path(exists=True), help="A thread pinning configuration file that gets executed after conf.")
@@ -117,7 +118,7 @@ import click
 @click.option('--debug', default=False, is_flag=True, help="Switch to get a lot of printout and dot files")
 @click.argument('json_dir', type=click.Path())
 
-def cli(timing_partition_name, host_timing, port_timing, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, clock_speed_hz, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
+def cli(timing_partition_name, host_timing, port_timing, base_command_port, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, clock_speed_hz, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
         thread_pinning_file,
         token_count, data_file, output_path, disable_trace, use_felix, use_ssp, host_df, host_dfo, host_ru, host_trigger, host_hsi, host_tpw, host_tprtc, host_dqm, region_id, latency_buffer_size,
         hsi_hw_connections_file, hsi_device_name, hsi_readout_period, control_hsi_hw, hsi_endpoint_address, hsi_endpoint_partition, hsi_re_mask, hsi_fe_mask, hsi_inv_mask, hsi_source,
@@ -524,7 +525,7 @@ def cli(timing_partition_name, host_timing, port_timing, number_of_data_producer
     from daqconf.core.conf_utils import make_system_command_datas,generate_boot, write_json_files
     system_command_datas = make_system_command_datas(the_system, verbose=debug)
     # Override the default boot.json with the one from minidaqapp
-    boot = generate_boot(the_system.apps,
+    boot = generate_boot(the_system.apps, base_command_port=base_command_port,
                          ers_settings=ers_settings, info_svc_uri=info_svc_uri,
                          disable_trace=disable_trace, use_kafka=use_kafka)
     

--- a/scripts/daqconf_timing_gen
+++ b/scripts/daqconf_timing_gen
@@ -24,6 +24,7 @@ moo.io.default_load_path = get_moo_model_path()
 import click
 
 @click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--base-command-port', type=int, default=3333, help="Base port of application command endpoints")
 @click.option('--clock-speed-hz', type=int, default=50000000)
 @click.option('--disable-trace', is_flag=True, help="Do not enable TRACE (default TRACE_FILE is /tmp/trace_buffer_\${HOSTNAME}_\${USER})")
 @click.option('--host-thi', default='localhost', help='Host to run the (global) timing hardware interface app on')
@@ -46,7 +47,7 @@ import click
 @click.option('--debug', default=False, is_flag=True, help="Switch to get a lot of printout and dot files")
 @click.argument('json_dir', type=click.Path())
 
-def cli(clock_speed_hz, disable_trace, host_thi, port_thi, host_tmc, host_tfc, 
+def cli(base_command_port, clock_speed_hz, disable_trace, host_thi, port_thi, host_tmc, host_tfc, 
         gather_interval, gather_interval_debug, timing_hw_connections_file, 
         opmon_impl, ers_impl, pocket_url, 
         hsi_device_name, master_device_name, master_send_delays_period, master_clock_file, master_clock_mode, 
@@ -148,7 +149,7 @@ def cli(clock_speed_hz, disable_trace, host_thi, port_thi, host_tmc, host_tfc,
     from daqconf.core.conf_utils import make_system_command_datas,generate_boot, write_json_files
     system_command_datas = make_system_command_datas(the_system, verbose=debug)
     # Override the default boot.json with the one from minidaqapp
-    boot = generate_boot(the_system.apps, ers_settings=ers_settings, info_svc_uri=info_svc_uri,
+    boot = generate_boot(the_system.apps, base_command_port=base_command_port, ers_settings=ers_settings, info_svc_uri=info_svc_uri,
                               disable_trace=disable_trace, use_kafka=use_kafka)
 
     system_command_datas['boot'] = boot


### PR DESCRIPTION
The base/default command port is hardcoded to `3333` in `generate_boot`. This leads to conflict when applications from multiple configurations are running on the same host. This PR changes the command port base value into  a`generate_boot` argument and exposes to as a script option