### PR TITLE
rm duplicate line

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -529,7 +529,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
 
     # Make boot.json config
     from daqconf.core.conf_utils import make_system_command_datas,generate_boot, write_json_files
-    system_command_datas = make_system_command_datas(the_system, verbose=debug)
 
     # HACK: Make sure RUs start after trigger
     forced_deps = []


### PR DESCRIPTION
This line was left after a merge conflict with develop wasn't properly fixed.
It fixes https://github.com/DUNE-DAQ/daqconf/issues/92
