### PR TITLE
Revert "Correct DFO host"

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -351,7 +351,7 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
     the_system.apps['dfo'] = get_dfo_app(
         DF_COUNT = len(host_df),
         TOKEN_COUNT = trigemu_token_count,
-        HOST=host_dfo,
+        HOST=host_trigger,
         DEBUG=debug)
 
 
@@ -532,7 +532,7 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
 
     # HACK: Make sure RUs start after trigger
     forced_deps = []
-
+    
     for i,host in enumerate(host_ru):
         ru_name = ru_app_names[i]
         forced_deps.append(['trigger', ru_name])


### PR DESCRIPTION
Reverts DUNE-DAQ/daqconf#102 so that patches are separated from releases. 