### PR TITLE
Dynamic queue size between TRB and DataWriter to handle long-window-readout

### DIFF
--- a/python/daqconf/apps/dataflow_gen.py
+++ b/python/daqconf/apps/dataflow_gen.py
@@ -45,6 +45,7 @@ def get_dataflow_app(HOSTIDX=0,
                      TPC_REGION_NAME_PREFIX="APA",
                      MAX_FILE_SIZE=4*1024*1024*1024,
                      MAX_TRIGGER_RECORD_WINDOW=0,
+                     MAX_EXPECTED_TR_SEQUENCES=1,
                      HOST="localhost",
                      HAS_DQM=False,
                      DEBUG=False):
@@ -93,7 +94,9 @@ def get_dataflow_app(HOSTIDX=0,
 
     mgraph=ModuleGraph(modules)
 
-    mgraph.connect_modules("trb.trigger_record_output", "datawriter.trigger_record_input", "trigger_records")
+    queue_size_based_on_number_of_sequences = max(10, int(MAX_EXPECTED_TR_SEQUENCES * 1.1))
+    mgraph.connect_modules("trb.trigger_record_output", "datawriter.trigger_record_input", "trigger_records",
+                           queue_size_based_on_number_of_sequences)
     mgraph.add_endpoint(f"trigger_decision_{HOSTIDX}", "trb.trigger_decision_input", Direction.IN)
     mgraph.add_endpoint("triginh", "datawriter.token_output", Direction.OUT, toposort=True)
     if HAS_DQM:

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -428,6 +428,7 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
 
         app_name = f'dataflow{i}'
         df_app_names.append(app_name)
+        max_expected_tr_sequences = 1 if max_trigger_record_window < 1 else ((trigger_window_before_ticks + trigger_window_after_ticks) / max_trigger_record_window)
         the_system.apps[app_name] = get_dataflow_app(
             HOSTIDX = i,
             OUTPUT_PATH = output_path,
@@ -435,6 +436,7 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             TPC_REGION_NAME_PREFIX = tpc_region_name_prefix,
             MAX_FILE_SIZE = max_file_size,
             MAX_TRIGGER_RECORD_WINDOW = max_trigger_record_window,
+            MAX_EXPECTED_TR_SEQUENCES = max_expected_tr_sequences,
             HOST=host,
             HAS_DQM=enable_dqm,
             DEBUG=debug


### PR DESCRIPTION
In tests of long-window-readout, Wes and I have noticed there can be complaints in the dataflow processes about failing to push an element onto a queue within the specified timeout.  The queue in question is the one between the TriggerRecordBuilder and the DataWriter, and its default size is 10.

This problem happens when there is a large burst of TriggerRecords associated with a single long-window-readout trigger.  For example, with a 1 second readout window and a max window size per TR of 4 msec, there will be 250 TriggerRecords associated with each trigger, and those TRs can appear in the TRB very quickly.

The code changes in this PR make the size of the TRB-DW queue dynamic, based on the maximum number of TRs expected per trigger (plus a little safety factor).