### PR TITLE
Eflumerf/region id and topics

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -145,7 +145,7 @@ def get_readout_app(RU_CONFIG=[],
                                           emulator_mode = EMULATOR_MODE,
                                           error_counter_threshold=100,
                                           error_reset_freq=10000,
-                                          tpset_topic=RU_CONFIG[RUIDX]["tpset_topics"][idx]
+                                          tpset_topic="TPSets"
                                       ),
                                       requesthandlerconf= rconf.RequestHandlerConf(
                                           latency_buffer_size = LATENCY_BUFFER_SIZE,
@@ -192,7 +192,7 @@ def get_readout_app(RU_CONFIG=[],
                 queues += [Queue(f"datahandler_{link_num}.errored_frames", 'errored_frame_consumer.input_queue', "errored_frames_q")]
 
             if SOFTWARE_TPG_ENABLED: 
-                tpset_topic = RU_CONFIG[RUIDX]["tpset_topics"][idx]
+                tpset_topic = "TPSets"
             else:
                 tpset_topic = "None"
             modules += [DAQModule(name = f"datahandler_{link_num}",
@@ -337,7 +337,7 @@ def get_readout_app(RU_CONFIG=[],
             tp_links = 1
         for idx in range(tp_links):
             assert total_link_count < 1000
-            mgraph.add_endpoint(f"tpsets_ru{RUIDX}_link{idx}", f"tp_datahandler_{idx}.tpset_out",    Direction.OUT, topic=[RU_CONFIG[RUIDX]["tpset_topics"][idx]])
+            mgraph.add_endpoint(f"tpsets_ru{RUIDX}_link{idx}", f"tp_datahandler_{idx}.tpset_out",    Direction.OUT, topic=["TPSets"])
             mgraph.add_fragment_producer(region = RU_CONFIG[RUIDX]["region_id"], element = idx + 1000, system = SYSTEM_TYPE,
                                     requests_in   = f"tp_datahandler_{idx}.request_input",
                                     fragments_out = f"tp_datahandler_{idx}.fragment_queue")
@@ -349,7 +349,7 @@ def get_readout_app(RU_CONFIG=[],
         else:
             link_num = idx
         if SOFTWARE_TPG_ENABLED:
-            mgraph.add_endpoint(f"tpsets_ru{RUIDX}_link{idx}", f"datahandler_{link_num}.tpset_out",    Direction.OUT, topic=[RU_CONFIG[RUIDX]["tpset_topics"][idx]])
+            mgraph.add_endpoint(f"tpsets_ru{RUIDX}_link{idx}", f"datahandler_{link_num}.tpset_out",    Direction.OUT, topic=["TPSets"])
             mgraph.add_endpoint(f"timesync_tp_dlh_ru{RUIDX}_{idx}", f"tp_datahandler_{link_num}.timesync_output",    Direction.OUT, ["Timesync"])
         
         if USE_FAKE_DATA_PRODUCERS:

--- a/python/daqconf/apps/tpwriter_gen.py
+++ b/python/daqconf/apps/tpwriter_gen.py
@@ -69,23 +69,7 @@ def get_tpwriter_app(RU_CONFIG,
 
     mgraph=ModuleGraph(modules)
 
-    # Connect up the TPSets from readout to the tpswriter. There's one
-    # stream per FELIX link, and the pub/sub topic for each link is
-    # stored in the RU_CONFIG that was passed as an argument to
-    # get_tpwriter_app
-    for ruidx, ru_config in enumerate(RU_CONFIG):
-        if FIRMWARE_TPG_ENABLED:
-            if ru_config["channel_count"] > 5:
-                tp_links = 2
-            else:
-                tp_links = 1
-        else:
-            tp_links = ru_config["channel_count"]
-        for link_idx in range(tp_links):
-            link_id=f"ru{ruidx}_link{link_idx}"
-            mgraph.add_endpoint(f"tpsets_{link_id}_sub", f"tpswriter.tpset_source", Direction.IN, topic=[ru_config["tpset_topics"][link_idx]])
-
-    # mgraph.add_endpoint("tpsets_into_writer", "tpswriter.tpset_source", Direction.IN)
+    mgraph.add_endpoint("TPSets", f"tpswriter.tpset_source", Direction.IN, topic=["TPSets"])
 
     tpw_app = App(modulegraph=mgraph, host=HOST)
 

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -354,7 +354,7 @@ def get_trigger_app(SOFTWARE_TPG_ENABLED: bool = False,
                 buf_name=f'buf_{link_id}'
                 global_link = link_idx+ru_config['start_channel'] # for the benefit of correct fragment geoid
 
-                mgraph.add_endpoint(f"tpsets_{link_id}_sub", f"channelfilter_{link_id}.tpset_source", Direction.IN, topic=[ru_config["tpset_topics"][link_idx]])
+                mgraph.add_endpoint(f"tpsets_{link_id}_sub", f"channelfilter_{link_id}.tpset_source", Direction.IN, topic=["TPSets"])
 
                 mgraph.add_fragment_producer(region=ru_config['region_id'], element=global_link, system="DataSelection",
                                              requests_in=f"{buf_name}.data_request_source",

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -268,11 +268,11 @@ def make_system_connections(the_system, verbose=False):
             make_external_connection(the_system, external_conn.external_name, app, external_conn.host, external_conn.port, external_conn.topic, external_conn.direction, verbose)
             external_uids.add(external_conn.external_name)
       for endpoint in the_system.apps[app].modulegraph.endpoints:
-        uids.append(endpoint.external_name)
         if len(endpoint.topic) == 0:
             if verbose:
                 console.log(f"Adding endpoint {endpoint.external_name}, app {app}, direction {endpoint.direction}")
             endpoint_map[endpoint.external_name] += [{"app": app, "endpoint": endpoint}]
+            uids.append(endpoint.external_name)
         else:
             if verbose:
                 console.log(f"Getting topics for endpoint {endpoint.external_name}, app {app}, direction {endpoint.direction}")

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -55,7 +55,7 @@ import click
 @click.option('--host-tpw', default='localhost', help='Host to run the TPWriter app on')
 @click.option('--host-tprtc', default='localhost', help='Host to run the timing partition controller app on')
 @click.option('--host-dqm', multiple=True, default=['localhost'], help='Host to run the DQM aps on')
-@click.option('--region-id', multiple=True, default=[0], help="Define the Region IDs for the RUs. If only specified once, will apply to all RUs.")
+@click.option('--region-id', multiple=True, default=[], help="Define the Region IDs for the RUs. If not specified, each RU will be assigned a Region ID based on declared order.")
 @click.option('--latency-buffer-size', default=499968, help="Size of the latency buffers (in number of elements)")
 # hsi readout options
 @click.option('--hsi-hw-connections-file', default="${TIMING_SHARE}/config/etc/connections.xml", help='Real timing hardware only: path to hardware connections file')
@@ -193,8 +193,13 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
     else:
         trigemu_token_count = 0
 
-    if (len(region_id) != len(host_ru)) and (len(region_id) != 1):
-        raise Exception("--region-id should be specified either once only or once for each --host-ru!")
+    if (len(region_id) != len(host_ru)) and (len(region_id) != 0):
+        raise Exception("--region-id should be specified once for each --host-ru, or not at all!")
+    if len(region_id) == 0:
+        region_id_temp = []
+        for reg in range(len(host_ru)):
+            region_id_temp.append(reg)
+        region_id = tuple(region_id_temp)
 
     if use_hsi_hw and not hsi_device_name:
         raise Exception("If --use-hsi-hw flag is set to true, --hsi-device-name must be specified!")
@@ -249,19 +254,9 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
     ru_configs = []
     ru_channel_counts = {}
     for region in region_id: ru_channel_counts[region] = 0
-    regionidx = 0
 
     ru_app_names=[f"ruflx{idx}" if use_felix else f"ruemu{idx}" for idx in range(len(host_ru))]
     dqm_app_names = [f"dqm{idx}_ru" for idx in range(len(host_ru))]
-
-    if enable_firmware_tpg:
-        if number_of_data_producers > 5:
-            n_tp = 2
-        else:
-            n_tp = 1
-        topic_tpsets = [ f"topic_tpsets_ru{region_id[regionidx]}_link{i}" for i in range(n_tp) ]
-    else:
-        topic_tpsets = [ f"topic_tpsets_ru{region_id[regionidx]}_link{i}" for i in range(number_of_data_producers) ]
 
     for hostidx,ru_host in enumerate(ru_app_names):
         cardid = 0
@@ -272,12 +267,10 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             host_id_dict[host_ru[hostidx]] = 0
         ru_configs.append( {"host": host_ru[hostidx],
                             "card_id": cardid,
-                            "region_id": region_id[regionidx],
-                            "start_channel": ru_channel_counts[region_id[regionidx]],
-                            "channel_count": number_of_data_producers,
-                            "tpset_topics":  topic_tpsets} )
-        ru_channel_counts[region_id[regionidx]] += number_of_data_producers
-        if len(region_id) != 1: regionidx = regionidx + 1
+                            "region_id": region_id[hostidx],
+                            "start_channel": ru_channel_counts[region_id[hostidx]],
+                            "channel_count": number_of_data_producers })
+        ru_channel_counts[region_id[hostidx]] += number_of_data_producers
 
     if use_hsi_hw:
         the_system.apps["hsi"] = get_hsi_app(

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -195,6 +195,8 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
 
     if (len(region_id) != len(host_ru)) and (len(region_id) != 0):
         raise Exception("--region-id should be specified once for each --host-ru, or not at all!")
+
+    # TODO, Eric Flumerfelt <eflumerf@github.com> 22-June-2022: Fix if/when multiple frontend types are supported. (Use https://click.palletsprojects.com/en/8.1.x/options/#multi-value-options for RU host/frontend/region config?)
     if len(region_id) == 0:
         region_id_temp = []
         for reg in range(len(host_ru)):


### PR DESCRIPTION
Replaces https://github.com/DUNE-DAQ/daqconf/pull/41 (mostly)

Change TPSet connections to use "TPSets" as their topic. Make TPWriter use the "TPSets" topic as the input.

Update --region-id to assign incremental region IDs to RUs if not
specified on command line.

Note that multi-frontend systems are not currently supported by
daqconf_multiru_gen, and when they are, the region-id logic may need
updates.