### PR TITLE
Tweak topographical sort (and add forced dependencies)

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -330,9 +330,9 @@ def get_trigger_app(SOFTWARE_TPG_ENABLED: bool = False,
             mgraph.connect_modules(f'tasettee_region_{region_id}.output1', f'tazipper.input', "tas_to_tazipper",      size_hint=1000)
             mgraph.connect_modules(f'tasettee_region_{region_id}.output2', f'ta_buf_region_{region_id}.taset_source', size_hint=1000)
     
-    mgraph.add_endpoint("hsievents", None, Direction.IN, toposort=True)
-    mgraph.add_endpoint("td_to_dfo", None, Direction.OUT)
-    mgraph.add_endpoint("df_busy_signal", None, Direction.IN, toposort=True)
+    mgraph.add_endpoint("hsievents", None, Direction.IN)
+    mgraph.add_endpoint("td_to_dfo", None, Direction.OUT, toposort=True)
+    mgraph.add_endpoint("df_busy_signal", None, Direction.IN)
 
     mgraph.add_fragment_producer(region=TC_REGION_ID, element=TC_ELEMENT_ID, system="DataSelection",
                                  requests_in="tc_buf.data_request_source",

--- a/python/daqconf/core/fragment_producers.py
+++ b/python/daqconf/core/fragment_producers.py
@@ -136,7 +136,7 @@ def connect_fragment_producers(app_name, the_system, verbose=False):
         fragment_connection_name = f"fragments_to_{df_name}"
         app.modulegraph.add_endpoint(fragment_connection_name, None, Direction.OUT)
         df_mgraph = df_app.modulegraph
-        df_mgraph.add_endpoint(fragment_connection_name, "trb.data_fragment_all", Direction.IN)            
+        df_mgraph.add_endpoint(fragment_connection_name, "trb.data_fragment_all", Direction.IN, toposort=True)            
         df_mgraph.add_endpoint(request_connection_name, f"trb.request_output_{app_name}", Direction.OUT)
 
         # Add the new geoid-to-connections map to the

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -537,7 +537,18 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
 
     for i,host in enumerate(host_ru):
         ru_name = ru_app_names[i]
-        forced_deps.append(['trigger', ru_name])
+        forced_deps.append(['hsi', ru_name])
+        if enable_tpset_writing:
+            forced_deps.append(['tpwriter', ru_name])
+
+    if enable_dqm:
+        for i,host in enumerate(host_ru):
+            dqm_name = dqm_app_names[i]
+            forced_deps.append([dqm_name, 'dfo'])
+        for i,host in enumerate(host_df):
+            dqm_name = dqm_df_app_names[i]
+            forced_deps.append([dqm_name, 'dfo'])
+    forced_deps.append(['trigger','hsi'])
 
     system_command_datas = make_system_command_datas(the_system, forced_deps, verbose=debug)
 


### PR DESCRIPTION
To achieve desired stop order where DFO stops first, followed by dataflow, readout,
HSI, and finally trigger.

The rationale for this order is that trigger should have stopped issuing
triggers at pause, but needs to be around to respond to data requests
from other parts of the system. DFO will wait until all TRs are complete
before allowing the rest of the system to stop.

Resolves #115. Depends on https://github.com/DUNE-DAQ/dfmodules/pull/201