### PR TITLE
Reduce buffer timeouts and don't warn on TC data request timeouts

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -106,7 +106,8 @@ def get_trigger_app(SOFTWARE_TPG_ENABLED: bool = False,
                                                                                                     element_id = TC_ELEMENT_ID,
                                                                                                     # output_file = f"output_{idx + MIN_LINK}.out",
                                                                                                     stream_buffer_size = 8388608,
-                                                                                                    retry_count = 1000,
+                                                                                                    retry_count = 0,
+                                                                                                    warn_on_timeout = False,
                                                                                                     enable_raw_recording = False))),
                DAQModule(name = 'tctee_ttcm',
                          plugin = 'TCTee')]
@@ -241,7 +242,7 @@ def get_trigger_app(SOFTWARE_TPG_ENABLED: bool = False,
                                                                                                                  element_id = TA_ELEMENT_ID,
                                                                                                                  # output_file = f"output_{idx + MIN_LINK}.out",
                                                                                                                  stream_buffer_size = 8388608,
-                                                                                                                 retry_count = 1000,
+                                                                                                                 retry_count = 10,
                                                                                                                  enable_raw_recording = False)))]
 
             for idy in range(tp_links):
@@ -258,7 +259,7 @@ def get_trigger_app(SOFTWARE_TPG_ENABLED: bool = False,
                                                                                                                   element_id = idy,
                                                                                                                   # output_file = f"output_{idx + MIN_LINK}.out",
                                                                                                                   stream_buffer_size = 8388608,
-                                                                                                                  retry_count = 1000,
+                                                                                                                  retry_count = 10,
                                                                                                                   enable_raw_recording = False)))]
         assert(region_ids == region_ids1)
         


### PR DESCRIPTION
To implement the behaviour requested in https://github.com/DUNE-DAQ/trigger/issues/134 , this PR reduces the timeouts on the TP, TA and TC buffers.

Requires https://github.com/DUNE-DAQ/readoutlibs/pull/40 to be merged first