### PR TITLE
Change the default argument in generate_boot_common

### DIFF
--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -508,7 +508,7 @@ def generate_boot_common(
         disable_trace=False,
         use_kafka=False,
         verbose=False,
-        daq_app_exec_name:str="daq_application",
+        daq_app_exec_name:str="daq_application_ssh",
         extra_env_vars=dict(),
         external_connections=[]) -> dict:
     """


### PR DESCRIPTION
Default argument for `daq_app_exec_name` should be `"daq_application_ssh"` not `"daq_application"`