### PR TITLE
Strict host assignement for k8s

### DIFF
--- a/python/daqconf/core/app.py
+++ b/python/daqconf/core/app.py
@@ -227,7 +227,7 @@ class App:
 
         # rest here are K8s specifics
         self.node_selection = [{ # k8s (NB: self.host is ignored for k8s)
-            "strict": False,
+            "strict": True,
             "kubernetes.io/hostname": [host],
             # ... can be used to select a node (or a collection of node). All the terms here are ANDed
             # this means if you add a field here, there has to be a pod which satisfies ALL the requirements at the same time

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -230,7 +230,7 @@ def make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbos
 
     port = the_system.next_unassigned_port()
     address_receiver = f'tcp://0.0.0.0:{port}'
-    address_sender = f'tcp://${{{in_apps[0]}}}:{port}' if not use_k8s else f'tcp://{in_apps[0]}:{port}'
+    address_sender = f'tcp://{{{in_apps[0]}}}:{port}' if not use_k8s else f'tcp://{in_apps[0]}:{port}'
     the_system.connections[in_apps[0]] += [conn.ConnectionId(uid=endpoint_name, service_type="kNetReceiver", data_type="", uri=address_receiver)]
     for app in set(out_apps):
         the_system.connections[app] += [conn.ConnectionId(uid=endpoint_name, service_type="kNetSender", data_type="", uri=address_sender)]
@@ -350,7 +350,7 @@ def make_system_connections(the_system, verbose=False, use_k8s=False):
                 publishers += [endpoint["app"]]
                 if endpoint['endpoint'].external_name not in pubsub_connectionids:
                     port = the_system.next_unassigned_port()
-                    address = f'tcp://${{{endpoint["app"]}}}:{port}' if not use_k8s else f'tcp://{endpoint["app"]}:{port}'
+                    address = f'tcp://{{{endpoint["app"]}}}:{port}' if not use_k8s else f'tcp://{endpoint["app"]}:{port}'
                     pubsub_connectionids[endpoint['endpoint'].external_name] = conn.ConnectionId(
                         uid=endpoint['endpoint'].external_name,
                         service_type="kPublisher",

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -222,7 +222,7 @@ def make_external_connection(the_system, endpoint_name, app_name, host, port, to
             new_address = replace_localhost_ip(address)
             the_system.connections[app_name] += [conn.ConnectionId(uid=endpoint_name, service_type='kPublisher', data_type="", uri=new_address, topics=topic)]
 
-def make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbose):
+def make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbose, use_k8s=False):
     if verbose:
         console.log(f"Connection {endpoint_name}, Network")
     if len(in_apps) > 1:
@@ -230,12 +230,12 @@ def make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbos
 
     port = the_system.next_unassigned_port()
     address_receiver = f'tcp://0.0.0.0:{port}'
-    address_sender = f'tcp://{{{in_apps[0]}}}:{port}'
+    address_sender = f'tcp://${{{in_apps[0]}}}:{port}' if not use_k8s else f'tcp://{in_apps[0]}:{port}'
     the_system.connections[in_apps[0]] += [conn.ConnectionId(uid=endpoint_name, service_type="kNetReceiver", data_type="", uri=address_receiver)]
     for app in set(out_apps):
         the_system.connections[app] += [conn.ConnectionId(uid=endpoint_name, service_type="kNetSender", data_type="", uri=address_sender)]
 
-def make_system_connections(the_system, verbose=False):
+def make_system_connections(the_system, verbose=False, use_k8s=False):
     """Given a system with defined apps and endpoints, create the
     set of connections that satisfy the endpoints.
 
@@ -327,10 +327,10 @@ def make_system_connections(the_system, verbose=False):
                         make_queue_connection(the_system,in_app, f"{in_app}.{endpoint_name}", [in_app], [in_app], size, verbose)
 
             if paired_exactly == False:
-                make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbose)
+                make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbose, use_k8s=use_k8s)
 
         else:
-            make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbose)
+            make_network_connection(the_system, endpoint_name, in_apps, out_apps, verbose, use_k8s=use_k8s)
 
     pubsub_connectionids = {}
     for topic, endpoints in topic_map.items():
@@ -350,7 +350,7 @@ def make_system_connections(the_system, verbose=False):
                 publishers += [endpoint["app"]]
                 if endpoint['endpoint'].external_name not in pubsub_connectionids:
                     port = the_system.next_unassigned_port()
-                    address = f'tcp://{{{endpoint["app"]}}}:{port}'
+                    address = f'tcp://${{{endpoint["app"]}}}:{port}' if not use_k8s else f'tcp://{endpoint["app"]}:{port}'
                     pubsub_connectionids[endpoint['endpoint'].external_name] = conn.ConnectionId(
                         uid=endpoint['endpoint'].external_name,
                         service_type="kPublisher",
@@ -383,7 +383,7 @@ def make_system_connections(the_system, verbose=False):
                     conn_copy.uri = replace_localhost_ip(conn_copy.uri)
                     the_system.connections[publisher] += [conn_copy]
 
-def make_app_command_data(system, app, appkey, verbose=False):
+def make_app_command_data(system, app, appkey, verbose=False, use_k8s=False):
     """Given an App instance, create the 'command data' suitable for
     feeding to nanorc. The needed queues are inferred from from
     connections between modules, as are the start and stop order of the
@@ -402,7 +402,7 @@ def make_app_command_data(system, app, appkey, verbose=False):
     command_data = {}
 
     if len(system.connections) == 0:
-        make_system_connections(system, verbose)
+        make_system_connections(system, verbose, use_k8s=use_k8s)
 
     module_deps = make_module_deps(app, system.connections[appkey], verbose)
     if verbose:

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -276,6 +276,7 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
         console.log(f"Output data written to \"{output_path}\"")
 
     raw_data_pvcs = {}
+
     if use_k8s:
         if output_path != '.':
             if output_path != 'raw-data-storage':
@@ -358,7 +359,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             TIMING_PORT=port_timing,
             HOST=host_hsi,
             DEBUG=debug)
-        #next(iter(the_system.apps['hsi'].node_selection))["strict"] = True
     else:
         the_system.apps["hsi"] = get_fake_hsi_app(
             RUN_NUMBER = run_number,
@@ -387,7 +387,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             TIMING_PORT=port_timing,
             HOST=host_tprtc,
             DEBUG=debug)
-        #next(iter(the_system.apps['tprtc'].node_selection))["strict"] = True
 
     the_system.apps['trigger'] = get_trigger_app(
         SOFTWARE_TPG_ENABLED = enable_software_tpg,
@@ -443,8 +442,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             DATA_REQUEST_TIMEOUT=readout_data_request_timeout,
             DEBUG=debug)
         if use_k8s:
-            if the_system.apps[ru_name].host != "localhost":
-                next(iter(the_system.apps[ru_name].node_selection))["strict"] = True
             if use_felix:
                 the_system.apps[ru_name].resources = {
                     "felix.cern/flx": "2", # requesting 2 FLXs
@@ -494,14 +491,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             HOST=host_tpw,
             DEBUG=debug)
 
-        if raw_data_pvcs:
-            node_selection = {
-                "strict": True,
-                "dune.daq/role": ["raw-data-storage"],
-            }
-            the_system.apps[tpw_name].node_selection = [node_selection]
-            the_system.apps[tpw_name].pvcs += [raw_data_pvcs]
-
         if debug: console.log(f"{tpw_name} app: {the_system.apps[tpw_name]}")
 
     df_app_names = []
@@ -525,13 +514,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             HAS_DQM=enable_dqm,
             DEBUG=debug
         )
-        if raw_data_pvcs:
-            node_selection = {
-                "strict": True,
-                "dune.daq/role": ["raw-data-storage"],
-            }
-            the_system.apps[app_name].node_selection = [node_selection]
-            the_system.apps[app_name].pvcs += [raw_data_pvcs]
 
 
         if enable_dqm:
@@ -561,11 +543,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
                 NUM_DF_APPS=len(host_df),
                 FRONTEND_TYPE=frontend_type,
                 DEBUG=debug)
-            the_system.apps[dqm_name].pod_affinity += [{
-                 # run preferably on thesame host as dataflow
-                "app": [app_name],
-                "strict": False
-            }]
 
             if debug: console.log(f"{dqm_name} app: {the_system.apps[dqm_name]}")
 
@@ -581,10 +558,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             all_apps_except_ru += [app]
         if app.name not in ru_app_names+df_app_names:
             all_apps_except_ru_and_df += [name]
-
-    if use_k8s:
-        from daqconf.core.conf_utils import set_strict_anti_affinity
-        set_strict_anti_affinity(all_apps_except_ru, ru_app_names)
 
         # HACK
         boot_order = ru_app_names + df_app_names + [app for app in all_apps_except_ru_and_df]

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -639,7 +639,7 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
 
     # Arrange per-app command data into the format used by util.write_json_files()
     app_command_datas = {
-        name : make_app_command_data(the_system, app,name, verbose=debug)
+        name : make_app_command_data(the_system, app,name, verbose=debug, use_k8s=use_k8s)
         for name,app in the_system.apps.items()
     }
 


### PR DESCRIPTION
This PR makes the the K8s system SSH-like, by strictly assigning the pod to the node specified, except if that node isn't specified (i.e. the default: localhost).
There are a some stuff from https://github.com/DUNE-DAQ/daqconf/pull/141 which should be merged before