### PR TITLE
Mount raw data storage on the pod

### DIFF
--- a/python/daqconf/core/app.py
+++ b/python/daqconf/core/app.py
@@ -232,7 +232,7 @@ class App:
             # ... can be used to select a node (or a collection of node). All the terms here are ANDed
             # this means if you add a field here, there has to be a pod which satisfies ALL the requirements at the same time
         }] if host != 'localhost' else [] # if you add another entry in the node_selection list, the requirement are ORed, so any node that satisfies a requirement is good
-        self.pvcs = []
+        self.mounted_dirs = []
         self.resources = {}
         self.pod_affinity = []
         self.pod_anti_affinity = []

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -623,7 +623,7 @@ def update_with_k8s_boot_data(
             "exec": 'daq_application_k8s',
             "node-selection": app.node_selection,
             "port": base_command_port,
-            "pvcs": app.pvcs,
+            "mounted_dirs": app.mounted_dirs,
             "resources": app.resources,
             "affinity": app.pod_affinity,
             "anti-affinity": app.pod_anti_affinity,

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -275,25 +275,8 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
     if debug:
         console.log(f"Output data written to \"{output_path}\"")
 
-    raw_data_pvcs = {}
-    if use_k8s:
-        if output_path != '.':
-            if output_path != 'raw-data-storage':
-                raise RuntimeError("With K8s, --output-path can only be \"raw-data-storage\" or \".\" (nothing/default).")
-            # everything goes to the same place
-            new_output_path = "/"+output_path+"-"+''.join(random.choices(string.ascii_uppercase + string.digits, k=5))
-            raw_data_pvcs = {
-                "storage_class_name": output_path,
-                "claim_name": output_path,
-                "mount": new_output_path,
-                "read_only": False,
-            }
-            output_path = new_output_path
-            if debug:
-                console.log(f"Corresponding PVC: \"{output_path}\"")
-        else:
-            console.log(f"[red]No PVC! Data will be lost when terminating, and make sure \"{output_path}\" exists in the pod![/red]")
-
+    if use_k8s and output_path == '.':
+        output_path = os.getcwd()
 
     ru_app_names = [f"ruflx{idx}" if use_felix else f"ruemu{idx}" for idx in range(len(host_ru))]
     dqm_app_names = [f"dqm{idx}-ru" for idx in range(len(host_ru))]
@@ -493,6 +476,13 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             CLOCK_SPEED_HZ = clock_speed_hz,
             HOST=host_tpw,
             DEBUG=debug)
+        if use_k8s: ## TODO schema
+            the_system.apps[tpw_name].mounted_dirs += [{
+                'name': 'raw-data',
+                'physical_location':output_path,
+                'in_pod_location':output_path,
+                'read_only': False
+            }]
 
         if raw_data_pvcs:
             node_selection = {
@@ -525,13 +515,13 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
             HAS_DQM=enable_dqm,
             DEBUG=debug
         )
-        if raw_data_pvcs:
-            node_selection = {
-                "strict": True,
-                "dune.daq/role": ["raw-data-storage"],
-            }
-            the_system.apps[app_name].node_selection = [node_selection]
-            the_system.apps[app_name].pvcs += [raw_data_pvcs]
+        if use_k8s:
+            the_system.apps[app_name].mounted_dirs += [{
+                'name': 'raw-data',
+                'physical_location':output_path,
+                'in_pod_location':output_path,
+                'read_only': False,
+            }]
 
 
         if enable_dqm:


### PR DESCRIPTION
This PR scraps the PVC/PV and rancher utility that were used for raw data storage, and directly mounts the output dir on the dataflow and tpwriter.
There are stuff from https://github.com/DUNE-DAQ/daqconf/pull/141 which are needed to use it.
