### PR TITLE
Initial casual user instruction update for v3.1.0

### DIFF
--- a/docs/ConfigurationsForCasualUsers.md
+++ b/docs/ConfigurationsForCasualUsers.md
@@ -14,7 +14,7 @@ The tools to generate these configurations consist of a single Python script tha
 The config_gen files under `python/daqconf/` directory were developed to work with _nanorc_ package, which itself can be seen as a basic Finite State Machine that sends commands and drives the DAQ system.
 
 The created configurations will be called `daq_fakeNN` and there will be a `daq_fakeNN` directory created containing the produced configuration to be used with  _nanorc_.
-The configurations can be run interactively with `nanorc daq_fakeNN` from the `<work_dir>`.
+The configurations can be run interactively with `nanorc daq_fakeNN <partition_name>` from the `<work_dir>`.
 
 1) In order to get the full set of configuration options and their `help` , run :
 `daqconf_multiru_gen -h`
@@ -56,7 +56,7 @@ the default for any unspecified host options will be `localhost`
 
 7) Running _nanorc_ can be done in interactively or in batch mode, for the later you can specify a sequence of commands to drive MiniDAQ app, for example run :
 
- `nanorc daq_fake03 boot <partition_name> init conf start 103 wait 60 stop scrap terminate`
+ `nanorc daq_fake03 <partition_name> boot conf start_run 103 wait 60 stop_run shutdown`
 
 Where the `start <run_number>` command specifies the run_number value to be used.
 Any meaningful combination of commands is allowed.  Note that the `start` command includes an automatically-generated `resume` command to start the flow of triggers, and the `stop` command includes an automatically-generated `pause` command to stop the flow of triggers.

--- a/docs/InstructionsForCasualUsers.md
+++ b/docs/InstructionsForCasualUsers.md
@@ -6,15 +6,15 @@ Here are the steps that should be used when you first create your local software
 
 1. log into a system that has access to `/cvmfs/dunedaq.opensciencegrid.org/`
 2. `source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh`
-3. `setup_dbt dunedaq-v3.0.0`
-4. `dbt-create -c dunedaq-v3.0.0 <work_dir>`
+3. `setup_dbt dunedaq-v3.1.0`
+4. `dbt-create -c dunedaq-v3.1.0 <work_dir>`
 6. `cd <work_dir>`
 7. `dbt-workarea-env`
 9. download a raw data file, either by running
    "`curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/0XzhExSIMQJUsp0/download`"
    or clicking on the [CERNBox link](https://cernbox.cern.ch/index.php/s/0XzhExSIMQJUsp0/download)) and put it into `<work_dir>`
 11. `daqconf_multiru_gen -d $PWD/frames.bin -o . -s 10 daq_fake`
-12. `nanorc daq_fake boot ${USER}-test init conf start 101 wait 60 stop scrap terminate`
+12. `nanorc daq_fake ${USER}-test boot conf start_run 101 wait 60 stop_run shutdown`
 13. examine the contents of the HDf5 file with commands like the following:
    * `h5dump-shared -H -A swtest_run000101_0000_*.hdf5`
    * and
@@ -25,7 +25,7 @@ When you return to this work area (for example, after logging out and back in), 
 1. `cd <work_dir>`
 2. `source ./dbt-env.sh`
 4. `dbt-workarea-env`
-7. `nanorc daq_fake boot ${USER}-test init conf start 102 wait 60 stop scrap terminate`
+7. `nanorc daq_fake ${USER}-test boot conf start_run 102 wait 60 stop_run shutdown`
 
 
 More detailed explanations on how to create different configurations can be found in [Instructions for different configurations for first-time users](ConfigurationsForCasualUsers.md)


### PR DESCRIPTION
The v3.1.0 diagram that I found had text that was obsolete (talked about new features that we have deferred until later), and it had the same blocks in the diagram as the v3.0.0 version, so I didn't update the diagram.
And, of course, I'm guessing what the `setup_dbt` and `dbt-create` arguments should be, based on what we had in the past.