### PR TITLE
Update daqconf for wib2 file format

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -190,6 +190,9 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
     if enable_firmware_tpg and not use_felix:
         raise Exception("firmware TPG can only be used if real felix card is also used.")
 
+    if enable_software_tpg and not (frontend_type == 'wib' or frontend_type == 'wib2'):
+        raise Exception("Software TPG is only available for the wib/wib2 format at the moment!")
+
     if enable_firmware_tpg and use_fake_data_producers:
         raise Exception("Fake data producers don't support firmware tpg")
 

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -178,9 +178,6 @@ def cli(timing_partition_name, host_timing, port_timing, base_command_port, numb
         total_number_of_data_producers = number_of_data_producers * len(host_ru)
         console.log(f"Will setup {number_of_data_producers} TPC channels per host, for a total of {total_number_of_data_producers}")
 
-    if enable_software_tpg and frontend_type != 'wib':
-        raise Exception("Software TPG is only available for the wib at the moment!")
-
     if enable_software_tpg and use_fake_data_producers:
         raise Exception("Fake data producers don't support software tpg")
 


### PR DESCRIPTION
Removing the raise of exception when using the wib2 frame. At the moment it cannot be used for the wib2 format.