### PR TITLE
Add printout of defaults from schema to daqconf_multiru_gen -h.

### DIFF
--- a/python/daqconf/core/config_file.py
+++ b/python/daqconf/core/config_file.py
@@ -120,3 +120,18 @@ def parse_config_file(filename, configurer_conf):
             # return parse_ini(filename, configurer_conf), filename
 
     raise RuntimeError(f'Configuration {filename} doesn\'t exist')
+
+def helptree(ost, prefix=''):
+    if 'doc' in ost.keys():
+        output = f"{prefix}{ost['name']}: {ost['doc']}"
+    else:
+        output = f"{prefix}{ost['name']}:"
+    for field in ost['fields']:
+        if type(field['default']) is dict:
+            output += "\n" + helptree(field["default"], prefix + "    ")
+        else:
+            docstr = ""
+            if 'doc' in field.keys():
+                docstr = f": {field['doc']}"
+            output += f"\n{prefix}    {field['name']} (Default: {field['default']}){docstr}"
+    return output

--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -121,12 +121,12 @@ local cs = {
     s.field( "max_file_size",self.count, default=4*1024*1024*1024, doc="The size threshold when raw data files are closed (in bytes)"),
     s.field( "max_trigger_record_window",self.count, default=0, doc="The maximum size for the window of data that will included in a single TriggerRecord (in ticks). Readout windows that are longer than this size will result in TriggerRecords being split into a sequence of TRs. A zero value for this parameter means no splitting."),
 
-  ]),
-  dataflowapps: s.sequence("dataflowapps", self.dataflowapp),
+  ], doc="Element of the dataflow.apps array"),
+  dataflowapps: s.sequence("dataflowapps", self.dataflowapp, doc="List of dataflowapp instances"),
 
   dataflow: s.record("dataflow", [
     s.field( "host_dfo", self.host, default='localhost', doc="Sets the host for the DFO app"),
-    s.field("apps", self.dataflowapps, default=[]),
+    s.field("apps", self.dataflowapps, default=[], doc="Configuration for the dataflow apps (see dataflowapp for options)"),
   ]),
 
   dqm: s.record("dqm", [

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -27,6 +27,29 @@ def configure(ctx, param, filename):
 
     return parse_config_file(filename, daqconf_conf)
 
+def helptree(ost, prefix=''):
+    if 'doc' in ost.keys():
+        output = f"{prefix}{ost['name']}: {ost['doc']}"
+    else:
+        output = f"{prefix}{ost['name']}:"
+    for field in ost['fields']:
+        if type(field['default']) is dict:
+            output += "\n" + helptree(field["default"], prefix + "    ")
+        elif 'doc' in field.keys():
+            output += f"\n{prefix}    {field['name']} (Default: {field['default']}): {field['doc']}"
+        else:
+            output += f"\n{prefix}    {field['name']} (Default: {field['default']})"
+    return output
+
+
+def helptext():
+    moo.otypes.load_types('daqconf/confgen.jsonnet')
+    import dunedaq.daqconf.confgen as confgen
+
+    output = helptree(confgen.daqconf_multiru_gen().ost)
+    print(f"Configuration file parameters: \n{output}")
+    return "Configuration JSON file to load"
+
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -35,7 +58,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     type         = click.Path(dir_okay=False),
     default      = None,
     callback     = configure,
-    help         = 'Read option defaults from the specified JSON file',
+    help         = helptext(),
     show_default = True,
 )
 @click.option('--base-command-port', type=int, default=-1, help="Base port of application command endpoints")

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -27,24 +27,10 @@ def configure(ctx, param, filename):
 
     return parse_config_file(filename, daqconf_conf)
 
-def helptree(ost, prefix=''):
-    if 'doc' in ost.keys():
-        output = f"{prefix}{ost['name']}: {ost['doc']}"
-    else:
-        output = f"{prefix}{ost['name']}:"
-    for field in ost['fields']:
-        if type(field['default']) is dict:
-            output += "\n" + helptree(field["default"], prefix + "    ")
-        elif 'doc' in field.keys():
-            output += f"\n{prefix}    {field['name']} (Default: {field['default']}): {field['doc']}"
-        else:
-            output += f"\n{prefix}    {field['name']} (Default: {field['default']})"
-    return output
-
-
 def helptext():
     moo.otypes.load_types('daqconf/confgen.jsonnet')
     import dunedaq.daqconf.confgen as confgen
+    from daqconf.core.config_file import helptree
 
     output = helptree(confgen.daqconf_multiru_gen().ost)
     print(f"Configuration file parameters: \n{output}")

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -48,6 +48,7 @@ def helptext():
 
     output = helptree(confgen.daqconf_multiru_gen().ost)
     print(f"Configuration file parameters: \n{output}")
+    print(f"{helptree(confgen.dataflowapp().ost, '    ')}")
     return "Configuration JSON file to load"
 
 # Add -h as default help option


### PR DESCRIPTION
I'm creating this as a draft PR, since there are 2 questions I can think of right off the bat...

1. Is this helpful?
2. Should this be implemented lower down (i.e. config_file.py) and/or better so that it can be used elsewhere?

Unfortunately, click does its own reformatting to the provided option help text, so giving the whole thing results in very ugly output. Moo's `help(<obj>)` as seen [here](https://brettviren.github.io/moo/otypes.html#org9793c0c) is also hard to parse, which is why I manually walk the config structure.