### PR TITLE
add daqconf_DAQSHARE definition into cmake.in, so that other pkgs can…

### DIFF
--- a/cmake/daqconfConfig.cmake.in
+++ b/cmake/daqconfConfig.cmake.in
@@ -11,11 +11,15 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 
+set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}")
+
 else()
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
-set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
-include(${targets_file})
+#set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+#include(${targets_file})
+
+set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 
 endif()
 


### PR DESCRIPTION
… use daqconf when doing codegen

This is causing `listrev`, which recently added `daq_codegen( confgen.jsonnet DEP_PKGS daqconf TEMPLATES Structs.hpp.j2)`, to fail the nightly build with:

1. Targets file not found (which is reasonable since there's no cmake targets for daqconf);
2. daqconf_DAQSHARE is not defined.