### PR TITLE
Use a fragment_type for FakeDataProducers based on the selected frontend type

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -98,18 +98,23 @@ def get_readout_app(DRO_CONFIG=None,
 
     # Hack on strings to be used for connection instances: will be solved when data_type is properly used.
 
+    FAKEDATA_FRAGMENT_TYPE = "Unknown"
     FRONTEND_TYPE = DetID.subdetector_to_string(DetID.Subdetector(DRO_CONFIG.links[0].det_id))
     if ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 50000000):
         FRONTEND_TYPE = "wib"
+        FAKEDATA_FRAGMENT_TYPE = "ProtoWIB"
     elif ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 62500000):
         FRONTEND_TYPE = "wib2"
+        FAKEDATA_FRAGMENT_TYPE = "WIB"
     elif FRONTEND_TYPE== "HD_PDS" or FRONTEND_TYPE== "VD_Cathode_PDS" or FRONTEND_TYPE=="VD_Membrane_PDS":
         FRONTEND_TYPE = "pds_list"
+        FAKEDATA_FRAGMENT_TYPE = "DAPHNE"
     elif FRONTEND_TYPE== "VD_Top_TPC":
         FRONTEND_TYPE = "tde"
+        FAKEDATA_FRAGMENT_TYPE = "TDE_AMC"
     elif FRONTEND_TYPE== "ND_LAr":
         FRONTEND_TYPE = "pacman"
-    
+        FAKEDATA_FRAGMENT_TYPE = "PACMAN"
 
     if DEBUG: print(f'FRONTENT_TYPE={FRONTEND_TYPE}')
 
@@ -211,7 +216,7 @@ def get_readout_app(DRO_CONFIG=None,
                                   time_tick_diff = 25 if CLOCK_SPEED_HZ == 50000000 else 32, # WIB1 only if clock is WIB1 clock, otherwise WIB2
                                   frame_size = 464 if CLOCK_SPEED_HZ == 50000000 else 472, # WIB1 only if clock is WIB1 clock, otherwise WIB2
                                   response_delay = 0,
-                                  fragment_type = "FakeData",
+                                  fragment_type = FAKEDATA_FRAGMENT_TYPE,
                                   timesync_topic_name = "Timesync",
                                   ))]
         else:


### PR DESCRIPTION
This is related to getting the daq-systemtest/integtest/iceberg_real_hsi_test.py integration test working.