### PR TITLE
Fix the frontend type not being passed to DQM

### DIFF
--- a/python/daqconf/apps/dqm_gen.py
+++ b/python/daqconf/apps/dqm_gen.py
@@ -51,9 +51,21 @@ def get_dqm_app(DQM_IMPL='',
                 DF_RATE=10,
                 DF_ALGS='raw std fourier_plane',
                 DF_TIME_WINDOW=0,
-                FRONTEND_TYPE='wib',
+                DRO_CONFIG=None,
                 DEBUG=False,
                 ):
+
+    FRONTEND_TYPE = DetID.subdetector_to_string(DetID.Subdetector(DRO_CONFIG.links[0].det_id))
+    if ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 50000000):
+        FRONTEND_TYPE = "wib"
+    elif ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 62500000):
+        FRONTEND_TYPE = "wib2"
+    elif FRONTEND_TYPE== "HD_PDS" or FRONTEND_TYPE== "VD_Cathode_PDS" or FRONTEND_TYPE=="VD_Membrane_PDS":
+        FRONTEND_TYPE = "pds_list"
+    elif FRONTEND_TYPE== "VD_Top_TPC":
+        FRONTEND_TYPE = "tde"
+    elif FRONTEND_TYPE== "ND_LAr":
+        FRONTEND_TYPE = "pacman"
 
     if DQM_IMPL == 'cern':
         KAFKA_ADDRESS = "monkafka.cern.ch:30092"

--- a/python/daqconf/apps/dqm_gen.py
+++ b/python/daqconf/apps/dqm_gen.py
@@ -27,6 +27,8 @@ from daqconf.core.conf_utils import Direction
 from daqconf.core.daqmodule import DAQModule
 from daqconf.core.app import App,ModuleGraph
 
+from detdataformats._daq_detdataformats_py import *
+
 # Time to wait on pop()
 QUEUE_POP_WAIT_MS = 100
 # local clock speed Hz

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -73,8 +73,6 @@ def get_readout_app(DRO_CONFIG=None,
                     EAL_ARGS='-l 0-1 -n 3 -- -m [0:1].0 -j',
                     BASE_SOURCE_IP="10.73.139.",
                     DESTINATION_IP="10.73.139.17",
-                    FRONTEND_TYPE='wib',
-                    FAKEDATA_FRAGMENT_TYPE='ProtoWIB',
                     DEBUG=False):
     """Generate the json configuration for the readout process"""
     
@@ -84,6 +82,25 @@ def get_readout_app(DRO_CONFIG=None,
     if DEBUG: print(f"SSB fw_tp source ID map: {fw_tp_id_map}")
     if DEBUG: print(f"SSB fw_tp_out source ID map: {fw_tp_out_id_map}")
 
+    # Hack on strings to be used for connection instances: will be solved when data_type is properly used.
+
+    FAKEDATA_FRAGMENT_TYPE = "Unknown"
+    FRONTEND_TYPE = DetID.subdetector_to_string(DetID.Subdetector(DRO_CONFIG.links[0].det_id))
+    if ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 50000000):
+        FRONTEND_TYPE = "wib"
+        FAKEDATA_FRAGMENT_TYPE = "ProtoWIB"
+    elif ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 62500000):
+        FRONTEND_TYPE = "wib2"
+        FAKEDATA_FRAGMENT_TYPE = "WIB"
+    elif FRONTEND_TYPE== "HD_PDS" or FRONTEND_TYPE== "VD_Cathode_PDS" or FRONTEND_TYPE=="VD_Membrane_PDS":
+        FRONTEND_TYPE = "pds_list"
+        FAKEDATA_FRAGMENT_TYPE = "DAPHNE"
+    elif FRONTEND_TYPE== "VD_Top_TPC":
+        FRONTEND_TYPE = "tde"
+        FAKEDATA_FRAGMENT_TYPE = "TDE_AMC"
+    elif FRONTEND_TYPE== "ND_LAr":
+        FRONTEND_TYPE = "pacman"
+        FAKEDATA_FRAGMENT_TYPE = "PACMAN"
 
     if DEBUG: print(f'FRONTENT_TYPE={FRONTEND_TYPE}')
 

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -73,6 +73,8 @@ def get_readout_app(DRO_CONFIG=None,
                     EAL_ARGS='-l 0-1 -n 3 -- -m [0:1].0 -j',
                     BASE_SOURCE_IP="10.73.139.",
                     DESTINATION_IP="10.73.139.17",
+                    FRONTEND_TYPE='wib',
+                    FAKEDATA_FRAGMENT_TYPE='wib',
                     DEBUG=False):
     """Generate the json configuration for the readout process"""
     
@@ -82,25 +84,6 @@ def get_readout_app(DRO_CONFIG=None,
     if DEBUG: print(f"SSB fw_tp source ID map: {fw_tp_id_map}")
     if DEBUG: print(f"SSB fw_tp_out source ID map: {fw_tp_out_id_map}")
 
-    # Hack on strings to be used for connection instances: will be solved when data_type is properly used.
-
-    FAKEDATA_FRAGMENT_TYPE = "Unknown"
-    FRONTEND_TYPE = DetID.subdetector_to_string(DetID.Subdetector(DRO_CONFIG.links[0].det_id))
-    if ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 50000000):
-        FRONTEND_TYPE = "wib"
-        FAKEDATA_FRAGMENT_TYPE = "ProtoWIB"
-    elif ((FRONTEND_TYPE== "HD_TPC" or FRONTEND_TYPE== "VD_Bottom_TPC") and CLOCK_SPEED_HZ== 62500000):
-        FRONTEND_TYPE = "wib2"
-        FAKEDATA_FRAGMENT_TYPE = "WIB"
-    elif FRONTEND_TYPE== "HD_PDS" or FRONTEND_TYPE== "VD_Cathode_PDS" or FRONTEND_TYPE=="VD_Membrane_PDS":
-        FRONTEND_TYPE = "pds_list"
-        FAKEDATA_FRAGMENT_TYPE = "DAPHNE"
-    elif FRONTEND_TYPE== "VD_Top_TPC":
-        FRONTEND_TYPE = "tde"
-        FAKEDATA_FRAGMENT_TYPE = "TDE_AMC"
-    elif FRONTEND_TYPE== "ND_LAr":
-        FRONTEND_TYPE = "pacman"
-        FAKEDATA_FRAGMENT_TYPE = "PACMAN"
 
     if DEBUG: print(f'FRONTENT_TYPE={FRONTEND_TYPE}')
 

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -74,7 +74,7 @@ def get_readout_app(DRO_CONFIG=None,
                     BASE_SOURCE_IP="10.73.139.",
                     DESTINATION_IP="10.73.139.17",
                     FRONTEND_TYPE='wib',
-                    FAKEDATA_FRAGMENT_TYPE='wib',
+                    FAKEDATA_FRAGMENT_TYPE='ProtoWIB',
                     DEBUG=False):
     """Generate the json configuration for the readout process"""
     

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -249,6 +249,25 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
 #    if debug:
 #        console.log(f"Output data written to \"{output_path}\"")
 
+    # Hack on strings to be used for connection instances: will be solved when data_type is properly used.
+
+    fakedata_fragment_type = "Unknown"
+    frontend_type = DetID.subdetector_to_string(DetID.Subdetector(DRO_CONFIG.links[0].det_id))
+    if ((frontend_type== "HD_TPC" or frontend_type== "VD_Bottom_TPC") and readout.clock_speed_hz == 50000000):
+        frontend_type = "wib"
+        fakedata_fragment_type = "ProtoWIB"
+    elif ((frontend_type== "HD_TPC" or frontend_type== "VD_Bottom_TPC") and readout.clock_speed_hz == 62500000):
+        frontend_type = "wib2"
+        fakedata_fragment_type = "WIB"
+    elif frontend_type== "HD_PDS" or frontend_type== "VD_Cathode_PDS" or frontend_type=="VD_Membrane_PDS":
+        frontend_type = "pds_list"
+        fakedata_fragment_type = "DAPHNE"
+    elif frontend_type== "VD_Top_TPC":
+        frontend_type = "tde"
+        fakedata_fragment_type = "TDE_AMC"
+    elif frontend_type== "ND_LAr":
+        frontend_type = "pacman"
+        fakedata_fragment_type = "PACMAN"
 
     max_expected_tr_sequences = 1
     for df_config in appconfig_df.values():
@@ -390,6 +409,8 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
             EAL_ARGS=readout.eal_args,
             BASE_SOURCE_IP=readout.base_source_ip,
             DESTINATION_IP=readout.destination_ip,
+            FRONTEND_TYPE=frontend_type,
+            FAKEDATA_FRAGMENT_TYPE=fakedata_fragment_type,
             DEBUG=debug)
 
         if boot.use_k8s:
@@ -430,6 +451,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
                 FOURIER_PLANE_PARAMS=dqm.fourier_plane_params,
                 LINKS=dqm_links,
                 HOST=dqm.host_dqm[dro_idx % len(dqm.host_dqm)],
+                FRONTEND_TYPE=frontend_type,
                 DEBUG=debug)
 
             if debug: console.log(f"{dqm_name} app: {the_system.apps[dqm_name]}")
@@ -495,7 +517,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
                 DF_RATE=dqm.df_rate * len(host_df),
                 DF_ALGS=dqm.df_algs,
                 DF_TIME_WINDOW=trigger.trigger_window_before_ticks + trigger.trigger_window_after_ticks,
-                FRONTEND_TYPE='',
+                FRONTEND_TYPE=frontend_type,
                 DEBUG=debug)
 
             if debug: console.log(f"{dqm_name} app: {the_system.apps[dqm_name]}")

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -250,27 +250,6 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
 #    if debug:
 #        console.log(f"Output data written to \"{output_path}\"")
 
-    # Hack on strings to be used for connection instances: will be solved when data_type is properly used.
-
-    fakedata_fragment_type = "Unknown"
-    for dro_idx,dro_config in enumerate(dro_infos):
-        break
-    frontend_type = DetID.subdetector_to_string(DetID.Subdetector(dro_config.links[0].det_id))
-    if ((frontend_type== "HD_TPC" or frontend_type== "VD_Bottom_TPC") and readout.clock_speed_hz == 50000000):
-        frontend_type = "wib"
-        fakedata_fragment_type = "ProtoWIB"
-    elif ((frontend_type== "HD_TPC" or frontend_type== "VD_Bottom_TPC") and readout.clock_speed_hz == 62500000):
-        frontend_type = "wib2"
-        fakedata_fragment_type = "WIB"
-    elif frontend_type== "HD_PDS" or frontend_type== "VD_Cathode_PDS" or frontend_type=="VD_Membrane_PDS":
-        frontend_type = "pds_list"
-        fakedata_fragment_type = "DAPHNE"
-    elif frontend_type== "VD_Top_TPC":
-        frontend_type = "tde"
-        fakedata_fragment_type = "TDE_AMC"
-    elif frontend_type== "ND_LAr":
-        frontend_type = "pacman"
-        fakedata_fragment_type = "PACMAN"
 
     max_expected_tr_sequences = 1
     for df_config in appconfig_df.values():
@@ -412,8 +391,6 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
             EAL_ARGS=readout.eal_args,
             BASE_SOURCE_IP=readout.base_source_ip,
             DESTINATION_IP=readout.destination_ip,
-            FRONTEND_TYPE=frontend_type,
-            FAKEDATA_FRAGMENT_TYPE=fakedata_fragment_type,
             DEBUG=debug)
 
         if boot.use_k8s:
@@ -454,7 +431,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
                 FOURIER_PLANE_PARAMS=dqm.fourier_plane_params,
                 LINKS=dqm_links,
                 HOST=dqm.host_dqm[dro_idx % len(dqm.host_dqm)],
-                FRONTEND_TYPE=frontend_type,
+                DRO_CONFIG=dro_config,
                 DEBUG=debug)
 
             if debug: console.log(f"{dqm_name} app: {the_system.apps[dqm_name]}")
@@ -520,7 +497,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
                 DF_RATE=dqm.df_rate * len(host_df),
                 DF_ALGS=dqm.df_algs,
                 DF_TIME_WINDOW=trigger.trigger_window_before_ticks + trigger.trigger_window_after_ticks,
-                FRONTEND_TYPE=frontend_type,
+                DRO_CONFIG=dro_config, # This is coming from the readout loop
                 DEBUG=debug)
 
             if debug: console.log(f"{dqm_name} app: {the_system.apps[dqm_name]}")

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -9,6 +9,7 @@ from daqconf.core.metadata import write_metadata_file
 from daqconf.core.sourceid import SourceIDBroker, get_tpg_mode
 from daqconf.core.config_file import generate_cli_from_schema
 from detchannelmaps._daq_detchannelmaps_py import HardwareMapService
+from detdataformats._daq_detdataformats_py import *
 
 console = Console()
 
@@ -252,7 +253,9 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
     # Hack on strings to be used for connection instances: will be solved when data_type is properly used.
 
     fakedata_fragment_type = "Unknown"
-    frontend_type = DetID.subdetector_to_string(DetID.Subdetector(DRO_CONFIG.links[0].det_id))
+    for dro_idx,dro_config in enumerate(dro_infos):
+        break
+    frontend_type = DetID.subdetector_to_string(DetID.Subdetector(dro_config.links[0].det_id))
     if ((frontend_type== "HD_TPC" or frontend_type== "VD_Bottom_TPC") and readout.clock_speed_hz == 50000000):
         frontend_type = "wib"
         fakedata_fragment_type = "ProtoWIB"


### PR DESCRIPTION
During the SourceID changes the logic for getting the frontend type was moved to the readout config generation but DQM also needs it. I've assumed the frontend type is the same for every SourceID which I think it's fine for this release but we'll have to change it in the future