### PR TITLE
Backed out the passing of the enable_firmware_tpg flag to tpwriter_app…

### DIFF
--- a/python/daqconf/apps/tpwriter_gen.py
+++ b/python/daqconf/apps/tpwriter_gen.py
@@ -34,7 +34,6 @@ def get_tpwriter_app(
                      CLOCK_SPEED_HZ=50000000,
                      HARDWARE_MAP_FILE="./HardwareMap.txt",
                      SOURCE_IDX=998,
-                     FIRMWARE_TPG_ENABLED=False,
                      HOST="localhost",
                      DEBUG=False):
 
@@ -48,7 +47,6 @@ def get_tpwriter_app(
                           plugin = "TPStreamWriter",
                           conf = tpsw.ConfParams(tp_accumulation_interval_ticks=ONE_SECOND_INTERVAL_TICKS,
                               source_id=SOURCE_IDX,
-                              firmware_tpg_enabled=FIRMWARE_TPG_ENABLED,
                               data_store_parameters=hdf5ds.ConfParams(
                               name="tp_stream_writer",
                               operational_environment = OPERATIONAL_ENVIRONMENT,

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -514,7 +514,6 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
             CLOCK_SPEED_HZ = readout.clock_speed_hz,
             HARDWARE_MAP_FILE=readout.hardware_map_file,
             SOURCE_IDX=dfidx,
-            FIRMWARE_TPG_ENABLED=readout.enable_firmware_tpg,
             HOST=trigger.host_tpw,
             DEBUG=debug)
         if boot.use_k8s: ## TODO schema


### PR DESCRIPTION
…since the TPStreamWriter should only write 'SW' TPs.

This change is part of a more thorough fix for dfmodules Issue 231.  It is for consideration **after** v3.2.0.  It is coupled with PR 237 in the dfmodules repo.