### PR TITLE
Fix location of FakeCardReader in readout_gen's logic.

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -380,6 +380,26 @@ def get_readout_app(DRO_CONFIG=None,
                                                     pattern="",
                                                     threshold=FIRMWARE_HIT_THRESHOLD,
                                                     masks=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]) )]
+            if not FLX_INPUT:
+                fake_source = "fake_source"
+                card_reader = "FakeCardReader"
+                conf = sec.Conf(link_confs = [sec.LinkConfiguration(source_id=link.dro_source_id,
+                                                                    slowdown=DATA_RATE_SLOWDOWN_FACTOR,
+                                                                    queue_name=f"output_{link.dro_source_id}",
+                                                                    data_filename = DATA_FILE,
+                                                                    emu_frame_error_rate=0) for link in DRO_CONFIG.links],
+                                                                    queue_timeout_ms = QUEUE_POP_WAIT_MS)
+                if FRONTEND_TYPE=='pacman':
+                    fake_source = "pacman_source"
+                    card_reader = "PacmanCardReader"
+                    conf = pcr.Conf(link_confs = [pcr.LinkConfiguration(Source_ID=link.dro_source_id)
+                                                 for link in DRO_CONFIG.links],
+                                  zmq_receiver_timeout = 10000)
+                modules += [DAQModule(name = fake_source,
+                                      plugin = card_reader,
+                                      conf = conf)]
+                queues += [Queue(f"{fake_source}.output_{link.dro_source_id}",f"datahandler_{link.dro_source_id}.raw_input",f'{FRONTEND_TYPE}_link_{link.dro_source_id}', 100000) for link in DRO_CONFIG.links]
+
         else:
             NUMBER_OF_GROUPS = 1
             NUMBER_OF_LINKS_PER_GROUP = 1
@@ -409,30 +429,7 @@ def get_readout_app(DRO_CONFIG=None,
             queues += [Queue(f"nic_reader.output_{link.dro_source_id}",
                              f"datahandler_{link.dro_source_id}.raw_input",
                              f'{FRONTEND_TYPE}_link_{link.dro_source_id}', 100000) for link in DRO_CONFIG.links]
-
-    else:
-        fake_source = "fake_source"
-        card_reader = "FakeCardReader"
-        conf = sec.Conf(link_confs = [sec.LinkConfiguration(source_id=link.dro_source_id,
-                                                            slowdown=DATA_RATE_SLOWDOWN_FACTOR,
-                                                            queue_name=f"output_{link.dro_source_id}",
-                                                            data_filename = DATA_FILE,
-                                                            emu_frame_error_rate=0) for link in DRO_CONFIG.links],
-                                                            queue_timeout_ms = QUEUE_POP_WAIT_MS)
-        if FRONTEND_TYPE=='pacman':
-            fake_source = "pacman_source"
-            card_reader = "PacmanCardReader"
-            conf = pcr.Conf(link_confs = [pcr.LinkConfiguration(Source_ID=link.dro_source_id)
-                                            for link in DRO_CONFIG.links],
-                            zmq_receiver_timeout = 10000)
-        modules += [DAQModule(name = fake_source,
-                            plugin = card_reader,
-                            conf = conf)]
-        queues += [Queue(f"{fake_source}.output_{link.dro_source_id}",f"datahandler_{link.dro_source_id}.raw_input",f'{FRONTEND_TYPE}_link_{link.dro_source_id}', 100000) for link in DRO_CONFIG.links]
-
-
-
-
+                  
     # modules += [
     #     DAQModule(name = "fragment_sender",
     #                    plugin = "FragmentSender",


### PR DESCRIPTION
A recent PR made the FakeCardReader insertion logic only happen when `USE_FAKE_DATA_PRODUCERS` was true, but that is the configuration to enable `FakeDataProd` instead of `DataLinkHandler`. When reading a file, (e.g. `FLX_INPUT` and `ENABLE_DPDK_READER` are both false), `FakeDataProd` needs to be enabled.