### PR TITLE
Jhancock/234 configurable rte script usage

### DIFF
--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -656,8 +656,18 @@ def generate_boot(
     if conf.disable_trace:
         del boot["exec"][daq_app_exec_name]["env"]["TRACE_FILE"]
 
-    if (release_or_dev() == 'rel') or (conf.always_RTE_script):
-        boot['rte_script'] = get_rte_script()
+    match conf.RTE_script_settings:
+        case 0:
+            if (release_or_dev() == 'rel'):
+                boot['rte_script'] = get_rte_script()
+
+        case 1:
+            boot['rte_script'] = get_rte_script()
+
+        case 2:
+            pass
+
+    
 
     if not conf.use_k8s:
         update_with_ssh_boot_data(

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -656,7 +656,7 @@ def generate_boot(
     if conf.disable_trace:
         del boot["exec"][daq_app_exec_name]["env"]["TRACE_FILE"]
 
-    if release_or_dev() == 'rel':
+    if (release_or_dev() == 'rel') or (conf.always_RTE_script):
         boot['rte_script'] = get_rte_script()
 
     if not conf.use_k8s:

--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -42,7 +42,7 @@ local cs = {
     s.field( "use_k8s", self.flag, default=false, doc="Whether to use k8s"),
     s.field( "op_env", self.string, default='swtest', doc="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files"),
     s.field( "data_request_timeout_ms", self.count, default=1000, doc="The baseline data request timeout that will be used by modules in the Readout and Trigger subsystems (i.e. any module that produces data fragments). Downstream timeouts, such as the trigger-record-building timeout, are derived from this."),
-    s.filed( "always_RTE_script", self.flag, default=false, doc="If this is true, a RTE script will be used even when running in a dev area"),
+    s.field( "always_RTE_script", self.flag, default=false, doc="If this is true, a RTE script will be used even when running in a dev area"),
   ]),
 
   timing: s.record("timing", [

--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -42,6 +42,7 @@ local cs = {
     s.field( "use_k8s", self.flag, default=false, doc="Whether to use k8s"),
     s.field( "op_env", self.string, default='swtest', doc="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files"),
     s.field( "data_request_timeout_ms", self.count, default=1000, doc="The baseline data request timeout that will be used by modules in the Readout and Trigger subsystems (i.e. any module that produces data fragments). Downstream timeouts, such as the trigger-record-building timeout, are derived from this."),
+    s.filed( "always_RTE_script", self.flag, default=false, doc="If this is true, a RTE script will be used even when running in a dev area"),
   ]),
 
   timing: s.record("timing", [

--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -3,13 +3,14 @@
 
 local moo = import "moo.jsonnet";
 local s = moo.oschema.schema("dunedaq.daqconf.confgen");
-
+local nc = moo.oschema.numeric_constraints;
 // A temporary schema construction context.
 local cs = {
   port:            s.number(   "Port", "i4", doc="A TCP/IP port number"),
   freq:            s.number(   "Frequency", "u4", doc="A frequency"),
   rate:            s.number(   "Rate", "f8", doc="A rate as a double"),
   count:           s.number(   "count", "i8", doc="A count of things"),
+  three_choice:    s.number(   "threechoice", "i8", nc(minimum=0, exclusiveMaximum=3), doc="A choice between 0, 1, or 2"),
   flag:            s.boolean(  "Flag", doc="Parameter that can be used to enable or disable functionality"),
   monitoring_dest: s.enum(     "MonitoringDest", ["local", "cern", "pocket"]),
   path:            s.string(   "Path", doc="Location on a filesystem"),
@@ -42,7 +43,7 @@ local cs = {
     s.field( "use_k8s", self.flag, default=false, doc="Whether to use k8s"),
     s.field( "op_env", self.string, default='swtest', doc="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files"),
     s.field( "data_request_timeout_ms", self.count, default=1000, doc="The baseline data request timeout that will be used by modules in the Readout and Trigger subsystems (i.e. any module that produces data fragments). Downstream timeouts, such as the trigger-record-building timeout, are derived from this."),
-    s.field( "RTE_script_settings", self.count, default=0, doc="0 - Use an RTE script iff not in a dev environment, 1 - Always use RTE, 2 - never use RTE"),
+    s.field( "RTE_script_settings", self.three_choice, default=0, doc="0 - Use an RTE script iff not in a dev environment, 1 - Always use RTE, 2 - never use RTE"),
   ]),
 
   timing: s.record("timing", [

--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -42,7 +42,7 @@ local cs = {
     s.field( "use_k8s", self.flag, default=false, doc="Whether to use k8s"),
     s.field( "op_env", self.string, default='swtest', doc="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files"),
     s.field( "data_request_timeout_ms", self.count, default=1000, doc="The baseline data request timeout that will be used by modules in the Readout and Trigger subsystems (i.e. any module that produces data fragments). Downstream timeouts, such as the trigger-record-building timeout, are derived from this."),
-    s.field( "always_RTE_script", self.flag, default=false, doc="If this is true, a RTE script will be used even when running in a dev area"),
+    s.field( "RTE_script_settings", self.count, default=0, doc="0 - Use an RTE script iff not in a dev environment, 1 - Always use RTE, 2 - never use RTE"),
   ]),
 
   timing: s.record("timing", [


### PR DESCRIPTION
I have added a new possible field in the boot section of the config JSON: "always_RTE_script". If this is false (it defaults to this if unspecified), then RTE scripts will be used if you are NOT in a dev area. If it is true, then a RTE script will be used regardless of any areas.