### PR TITLE
set correct source id for tpsets

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -237,7 +237,8 @@ def get_readout_app(DRO_CONFIG=None,
                                           emulator_mode = EMULATOR_MODE,
                                           error_counter_threshold=100,
                                           error_reset_freq=10000,
-                                          tpset_topic="TPSets"
+                                          tpset_topic="TPSets",
+                                          tpset_sourceid=tp,
                                       ),
                                       requesthandlerconf= rconf.RequestHandlerConf(
                                           latency_buffer_size = LATENCY_BUFFER_SIZE,


### PR DESCRIPTION
fixes https://github.com/DUNE-DAQ/fdreadoutlibs/issues/72.
defines non-default values for TP source IDs