### PR TITLE
Initial commit

### DIFF
--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -53,6 +53,7 @@ local cs = {
     s.field("connectivity_service_host", self.host, default='127.0.0.1', doc="Hostname for the ConnectivityService"),
     s.field("connectivity_service_port", self.port, default=5000, doc="Port for the ConnectivityService"),
     s.field( "RTE_script_settings", self.three_choice, default=0, doc="0 - Use an RTE script iff not in a dev environment, 1 - Always use RTE, 2 - never use RTE"),
+    s.field( "use_data_network", self.flag, default = false, doc="Whether to use the data network (Won't work with k8s)"),
   ]),
 
   timing: s.record("timing", [

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -662,12 +662,17 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
         else:
             return control_hostname
 
+    if boot.use_data_network:
+        CDN = control_to_data_network
+    else:
+        CDN = None
+
     system_command_datas = make_system_command_datas(
         boot,
         the_system,
         forced_deps,
         verbose=debug,
-        control_to_data_network=control_to_data_network,
+        control_to_data_network=CDN,
     )
 
 


### PR DESCRIPTION
Adds an option to the conf ("use_data_network" false by default) saying whether to use the control_to_data_network function to find hostnames. Tested that nanorc runs correctly with the option set to true or false, and that config generation is aborted when both use_data_network and use_k8s are true. 