### PR TITLE
TPZipper cardinality setting bugfix

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -217,7 +217,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                 # tazipper.max_latency_ms, everything should be fine.
                 modules += [DAQModule(name = f'zip_{region_id}',
                                       plugin = 'TPZipper',
-                                              conf = tzip.ConfParams(cardinality=ta_conf["conf"].link_count,
+                                              conf = tzip.ConfParams(cardinality=len(TP_SOURCE_IDS),
                                                                      max_latency_ms=100,
                                                                      element_id=ta_conf["source_id"])),
                                     


### PR DESCRIPTION
The TPZipper cardinality was being set to the number of hardware links rather than the number of the TPSet queues during the config generation. This bugfix fixes that.

More info in  [DUNE-DAQ/trigger issue 167](https://github.com/DUNE-DAQ/trigger/issues/167).