### PR TITLE
Fix cardinality configuration changes

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -217,7 +217,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                 # tazipper.max_latency_ms, everything should be fine.
                 modules += [DAQModule(name = f'zip_{region_id}',
                                       plugin = 'TPZipper',
-                                              conf = tzip.ConfParams(cardinality=len(TP_SOURCE_IDS),
+                                              conf = tzip.ConfParams(cardinality=ta_conf["conf"].link_count,
                                                                      max_latency_ms=100,
                                                                      element_id=ta_conf["source_id"])),
                                     

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -217,7 +217,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                 # tazipper.max_latency_ms, everything should be fine.
                 modules += [DAQModule(name = f'zip_{region_id}',
                                       plugin = 'TPZipper',
-                                              conf = tzip.ConfParams(cardinality=ta_conf["conf"].link_count,
+                                              conf = tzip.ConfParams(cardinality=len(TP_SOURCE_IDS)/len(TA_SOURCE_IDS),
                                                                      max_latency_ms=100,
                                                                      element_id=ta_conf["source_id"])),
                                     


### PR DESCRIPTION
When we initially fixed the `cardinality` configuration, we forgot to take into account the tests for multiple readout applications, which divides the total number of input TP queues presented to the various `TPZippers`. This amendment accounts for that, and passes the `3ru_3df` integration tests provided in `dfmodules`.