### PR TITLE
added offset to TRB_DQM SourceIDs so that they are unique from backend TRBs

### DIFF
--- a/python/daqconf/apps/dqm_gen.py
+++ b/python/daqconf/apps/dqm_gen.py
@@ -53,6 +53,7 @@ def get_dqm_app(DQM_IMPL='',
                 DF_TIME_WINDOW=0,
                 DRO_CONFIG=None,
                 APP_NAME="dqm",
+                TRB_DQM_SOURCEID_OFFSET=0,
                 DEBUG=False,
                 ):
 
@@ -81,7 +82,7 @@ def get_dqm_app(DQM_IMPL='',
                             plugin='TriggerRecordBuilder',
                             conf=trb.ConfParams(
                                 general_queue_timeout=QUEUE_POP_WAIT_MS,
-                                source_id = DQMIDX,
+                                source_id = DQMIDX+TRB_DQM_SOURCEID_OFFSET,
                                 reply_connection_name = "",
                                 max_time_window=0
                             ))]

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -363,6 +363,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
         DEBUG=debug)
 
 
+    trb_dqm_sourceid_offset = sourceid_broker.get_next_source_id("TRBuilder")
     ru_app_names=[]
     dqm_app_names = []
     for dro_idx,dro_config in enumerate(dro_infos):
@@ -452,6 +453,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
                 FOURIER_CHANNEL_PARAMS=dqm.fourier_channel_params,
                 FOURIER_PLANE_PARAMS=dqm.fourier_plane_params,
                 LINKS=dqm_links,
+                TRB_DQM_SOURCEID_OFFSET=trb_dqm_sourceid_offset,
                 HOST=dqm.host_dqm[dro_idx % len(dqm.host_dqm)],
                 DRO_CONFIG=dro_config,
                 DEBUG=debug)


### PR DESCRIPTION
The TRB_DQM source IDs are not currently used for much, so this may be just a safety measure to make sure that they are unique in case they are used in the future.