### PR TITLE
Removed the TriggerRecordBuilder reply_connection_name configuration parameter

### DIFF
--- a/python/daqconf/apps/dataflow_gen.py
+++ b/python/daqconf/apps/dataflow_gen.py
@@ -51,7 +51,6 @@ def get_dataflow_app(HOSTIDX=0,
     modules += [DAQModule(name = 'trb',
                           plugin = 'TriggerRecordBuilder',
                           conf = trb.ConfParams(general_queue_timeout=QUEUE_POP_WAIT_MS,
-                                                reply_connection_name = "",
                                                 max_time_window=MAX_TRIGGER_RECORD_WINDOW,
                                                 source_id = HOSTIDX,
                                                 trigger_record_timeout_ms=TRB_TIMEOUT))]

--- a/python/daqconf/apps/dqm_gen.py
+++ b/python/daqconf/apps/dqm_gen.py
@@ -83,7 +83,6 @@ def get_dqm_app(DQM_IMPL='',
                             conf=trb.ConfParams(
                                 general_queue_timeout=QUEUE_POP_WAIT_MS,
                                 source_id = DQMIDX+TRB_DQM_SOURCEID_OFFSET,
-                                reply_connection_name = "",
                                 max_time_window=0
                             ))]
 

--- a/python/daqconf/core/fragment_producers.py
+++ b/python/daqconf/core/fragment_producers.py
@@ -137,6 +137,5 @@ def connect_all_fragment_producers(the_system, dataflow_name="dataflow", verbose
         old_trb_conf = df_mgraph.get_module(trb_module_name).conf
         df_mgraph.reset_module_conf(trb_module_name, trb.ConfParams(general_queue_timeout=old_trb_conf.general_queue_timeout,
                                                                source_id = old_trb_conf.source_id,
-                                                          reply_connection_name = fragment_connection_name,
                                                           max_time_window = old_trb_conf.max_time_window,
                                                           trigger_record_timeout_ms = old_trb_conf.trigger_record_timeout_ms))


### PR DESCRIPTION
…from all of the relevant scripts.  Now that we are storing this connection name at INIT time in th TRB code.

This is part of the easy fixes that we are doing as part of the ConnSvc consolidation.

This PR should be tested and review in conjunction with one in the dfmodules repo.