### PR TITLE
remove connections names from conf params and add the corresponding g…

### DIFF
--- a/python/daqconf/apps/dataflow_gen.py
+++ b/python/daqconf/apps/dataflow_gen.py
@@ -51,7 +51,6 @@ def get_dataflow_app(HOSTIDX=0,
     modules += [DAQModule(name = 'trb',
                           plugin = 'TriggerRecordBuilder',
                           conf = trb.ConfParams(general_queue_timeout=QUEUE_POP_WAIT_MS,
-                                                reply_connection_name = "",
                                                 max_time_window=MAX_TRIGGER_RECORD_WINDOW,
                                                 source_id = HOSTIDX,
                                                 trigger_record_timeout_ms=TRB_TIMEOUT))]

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -289,6 +289,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
         mgraph.connect_modules("ttcm.output",         "tctee_ttcm.input",             "TriggerCandidate", "ttcm_input", size_hint=1000)
         mgraph.connect_modules("tctee_ttcm.output1",  "mlt.trigger_candidate_input", "TriggerCandidate","tcs_to_mlt", size_hint=1000)
         mgraph.connect_modules("tctee_ttcm.output2",  "tc_buf.tc_source",             "TriggerCandidate","tcs_to_buf", size_hint=1000)
+        mgraph.add_endpoint("hsievents", "ttcm.hsi_input", "HSIEvent", Direction.IN)
 
     if len(TP_SOURCE_IDS) > 0:
         mgraph.connect_modules("tazipper.output", "tcm.input", data_type="TASet", size_hint=1000)
@@ -318,11 +319,8 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
             mgraph.connect_modules(f'tasettee_region_{region_id}.output1', f'tazipper.input', queue_name="tas_to_tazipper",     data_type="TASet", size_hint=1000)
             mgraph.connect_modules(f'tasettee_region_{region_id}.output2', f'ta_buf_region_{region_id}.taset_source',data_type="TASet", size_hint=1000)
 
-    if USE_HSI_INPUT:
-        mgraph.add_endpoint("hsievents", "hsi_input", "HSIEvent", Direction.IN)
-        
-    mgraph.add_endpoint("td_to_dfo", "td_output", "TriggerDecision", Direction.OUT, toposort=True)
-    mgraph.add_endpoint("df_busy_signal", "dfo_inhibit_input", "TriggerInhibit", Direction.IN)
+    mgraph.add_endpoint("td_to_dfo", "mlt.td_output", "TriggerDecision", Direction.OUT, toposort=True)
+    mgraph.add_endpoint("df_busy_signal", "mlt.dfo_inhibit_input", "TriggerInhibit", Direction.IN)
 
     mgraph.add_fragment_producer(id=TC_SOURCE_ID["source_id"], subsystem="Trigger",
                                  requests_in="tc_buf.data_request_source",

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -265,7 +265,6 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                                          s2=ttcm.map_t(signal_type=TTCM_S2,
                                                        time_before=TRIGGER_WINDOW_BEFORE_TICKS,
                                                        time_after=TRIGGER_WINDOW_AFTER_TICKS),
-                                         hsievent_connection_name = "hsievents",
                      hsi_trigger_type_passthrough=HSI_TRIGGER_TYPE_PASSTHROUGH))]
     
     # We need to populate the list of links based on the fragment
@@ -278,8 +277,6 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
     modules += [DAQModule(name = 'mlt',
                           plugin = 'ModuleLevelTrigger',
                           conf=mlt.ConfParams(links=[],  # To be updated later - see comment above
-                                              dfo_connection=f"td_to_dfo",
-                                              dfo_busy_connection=f"df_busy_signal",
                                               hsi_trigger_type_passthrough=HSI_TRIGGER_TYPE_PASSTHROUGH,
                           buffer_timeout=MLT_BUFFER_TIMEOUT,
                                               td_out_of_timeout=MLT_SEND_TIMED_OUT_TDS,
@@ -290,7 +287,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
 
     if USE_HSI_INPUT:
         mgraph.connect_modules("ttcm.output",         "tctee_ttcm.input",             "TriggerCandidate", "ttcm_input", size_hint=1000)
-        mgraph.connect_modules("tctee_ttcm.output1",  "mlt.trigger_candidate_source", "TriggerCandidate","tcs_to_mlt", size_hint=1000)
+        mgraph.connect_modules("tctee_ttcm.output1",  "mlt.trigger_candidate_input", "TriggerCandidate","tcs_to_mlt", size_hint=1000)
         mgraph.connect_modules("tctee_ttcm.output2",  "tc_buf.tc_source",             "TriggerCandidate","tcs_to_buf", size_hint=1000)
 
     if len(TP_SOURCE_IDS) > 0:
@@ -312,7 +309,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
         # Use connect_modules to connect up the Tees to the buffers/MLT,
         # as manually adding Queues doesn't give the desired behaviour
         mgraph.connect_modules("tcm.output",          "tctee_chain.input",           "TriggerCandidate", "chain_input", size_hint=1000)
-        mgraph.connect_modules("tctee_chain.output1", "mlt.trigger_candidate_source","TriggerCandidate", "tcs_to_mlt",  size_hint=1000)
+        mgraph.connect_modules("tctee_chain.output1", "mlt.trigger_candidate_input","TriggerCandidate", "tcs_to_mlt",  size_hint=1000)
         mgraph.connect_modules("tctee_chain.output2", "tc_buf.tc_source",             "TriggerCandidate","tcs_to_buf",  size_hint=1000)
 
 
@@ -322,10 +319,10 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
             mgraph.connect_modules(f'tasettee_region_{region_id}.output2', f'ta_buf_region_{region_id}.taset_source',data_type="TASet", size_hint=1000)
 
     if USE_HSI_INPUT:
-        mgraph.add_endpoint("hsievents", None, "HSIEvent", Direction.IN)
+        mgraph.add_endpoint("hsievents", "hsi_input", "HSIEvent", Direction.IN)
         
-    mgraph.add_endpoint("td_to_dfo", None, "TriggerDecision", Direction.OUT, toposort=True)
-    mgraph.add_endpoint("df_busy_signal", None, "TriggerInhibit", Direction.IN)
+    mgraph.add_endpoint("td_to_dfo", "td_output", "TriggerDecision", Direction.OUT, toposort=True)
+    mgraph.add_endpoint("df_busy_signal", "dfo_inhibit_input", "TriggerInhibit", Direction.IN)
 
     mgraph.add_fragment_producer(id=TC_SOURCE_ID["source_id"], subsystem="Trigger",
                                  requests_in="tc_buf.data_request_source",

--- a/python/daqconf/core/fragment_producers.py
+++ b/python/daqconf/core/fragment_producers.py
@@ -38,8 +38,6 @@ def set_mlt_links(the_system, mlt_app_name="trigger", verbose=False):
     mgraph = the_system.apps[mlt_app_name].modulegraph
     old_mlt_conf = mgraph.get_module("mlt").conf
     mgraph.reset_module_conf("mlt", mlt.ConfParams(links=mlt_links, 
-                                                   dfo_connection=old_mlt_conf.dfo_connection, 
-                                                   dfo_busy_connection=old_mlt_conf.dfo_busy_connection,
                                                    hsi_trigger_type_passthrough=old_mlt_conf.hsi_trigger_type_passthrough,
 						   buffer_timeout=old_mlt_conf.buffer_timeout,
                                                    td_out_of_timeout=old_mlt_conf.td_out_of_timeout,
@@ -57,8 +55,6 @@ def remove_mlt_link(the_system, source_id, mlt_app_name="trigger"):
         raise ValueError(f"SourceID {source_id} not in MLT links list")
     mlt_links.remove(source_id)
     mgraph.reset_module_conf("mlt", mlt.ConfParams(links=mlt_links, 
-                                                   dfo_connection=old_mlt_conf.dfo_connection, 
-                                                   dfo_busy_connection=old_mlt_conf.dfo_busy_connection,
                                                    hsi_trigger_type_passthrough=old_mlt_conf.hsi_trigger_type_passthrough,
                                                    buffer_timeout=old_mlt_conf.buffer_timeout,
 					       	   td_out_of_timeout=old_mlt_conf.td_out_of_timeout,
@@ -137,6 +133,5 @@ def connect_all_fragment_producers(the_system, dataflow_name="dataflow", verbose
         old_trb_conf = df_mgraph.get_module(trb_module_name).conf
         df_mgraph.reset_module_conf(trb_module_name, trb.ConfParams(general_queue_timeout=old_trb_conf.general_queue_timeout,
                                                                source_id = old_trb_conf.source_id,
-                                                          reply_connection_name = fragment_connection_name,
                                                           max_time_window = old_trb_conf.max_time_window,
                                                           trigger_record_timeout_ms = old_trb_conf.trigger_record_timeout_ms))


### PR DESCRIPTION
…raph endpoints.
Conf parameters containing connection names have been removed and the endpoint are added with a logical/global name to the modules graph.
This PR goes together with the corresponding one on trigger.