### PR TITLE
Added config param to the Readout confgen to enable the use of "now" as the playback data start time

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -430,6 +430,7 @@ def get_readout_app(DRO_CONFIG=None,
                                                                     data_filename = DATA_FILES[link.det_id] if link.det_id in DATA_FILES.keys() else DEFAULT_DATA_FILE,
                                                                     emu_frame_error_rate=0) for link in DRO_CONFIG.links],
                                 use_now_as_first_data_time=EMULATED_DATA_TIMES_START_WITH_NOW,
+                                clock_speed_hz=CLOCK_SPEED_HZ,
                                 queue_timeout_ms = QUEUE_POP_WAIT_MS)
                 if FRONTEND_TYPE=='pacman':
                     fake_source = "pacman_source"

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -80,6 +80,7 @@ def get_readout_app(DRO_CONFIG=None,
                     LATENCY_BUFFER_NUMA_AWARE = False,
                     LATENCY_BUFFER_ALLOCATION_MODE = False,
                     CARD_ID_OVERRIDE = -1,
+                    EMULATED_DATA_TIMES_START_WITH_NOW = False,
                     DEBUG=False):
     """Generate the json configuration for the readout process"""
     
@@ -428,7 +429,8 @@ def get_readout_app(DRO_CONFIG=None,
                                                                     queue_name=f"output_{link.dro_source_id}",
                                                                     data_filename = DATA_FILES[link.det_id] if link.det_id in DATA_FILES.keys() else DEFAULT_DATA_FILE,
                                                                     emu_frame_error_rate=0) for link in DRO_CONFIG.links],
-                                                                    queue_timeout_ms = QUEUE_POP_WAIT_MS)
+                                use_now_as_first_data_time=EMULATED_DATA_TIMES_START_WITH_NOW,
+                                queue_timeout_ms = QUEUE_POP_WAIT_MS)
                 if FRONTEND_TYPE=='pacman':
                     fake_source = "pacman_source"
                     card_reader = "PacmanCardReader"

--- a/schema/daqconf/confgen.jsonnet
+++ b/schema/daqconf/confgen.jsonnet
@@ -143,6 +143,7 @@ local cs = {
     s.field( "base_source_ip", self.string, default='10.73.139.', doc='First part of the IP of the source'),
     s.field( "destination_ip", self.string, default='10.73.139.17', doc='IP of the destination'),
     s.field( "numa_config", self.numa_config, default=self.numa_config, doc='Configuration of FELIX NUMA IDs'),
+    s.field( "emulated_data_times_start_with_now", self.flag, default=false, doc="If active, the timestamp of the first emulated data frame is set to the current wallclock time"),
   ]),
 
   trigger_algo_config: s.record("trigger_algo_config", [

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -455,6 +455,7 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
             LATENCY_BUFFER_NUMA_AWARE = latency_numa,
             LATENCY_BUFFER_ALLOCATION_MODE = latency_preallocate,
             CARD_ID_OVERRIDE = card_override,
+            EMULATED_DATA_TIMES_START_WITH_NOW = readout.emulated_data_times_start_with_now,
             DEBUG=debug)
 
         if boot.use_k8s:


### PR DESCRIPTION
That is, this new parameter allows the use of the current wallclock time as the first data timestamp when replaying data from files.

This PR should be tested and reviewed with the companion one in the `readoutlibs` package.  ([number 99](https://github.com/DUNE-DAQ/readoutlibs/pull/99))