### PR TITLE
Fix readout map configuration.

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -99,18 +99,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                     MLT_SEND_TIMED_OUT_TDS: bool = False,
                     MLT_MAX_TD_LENGTH_MS: int = 1000,
                     MLT_IGNORE_TC: list = [],
-                    MLT_READOUT_MAP: dict = {
-                      'c0': {'candidate_type': 0, 'time_before': 10000, 'time_after': 20000},
-                      'c1': {'candidate_type': 1, 'time_before': 10000, 'time_after': 20000},
-                      'c2': {'candidate_type': 2, 'time_before': 10000, 'time_after': 20000},
-                      'c3': {'candidate_type': 3, 'time_before': 10000, 'time_after': 20000},
-                      'c4': {'candidate_type': 4, 'time_before': 10000, 'time_after': 20000},
-                      'c5': {'candidate_type': 5, 'time_before': 10000, 'time_after': 20000},
-                      'c6': {'candidate_type': 6, 'time_before': 10000, 'time_after': 20000},
-                      'c7': {'candidate_type': 7, 'time_before': 10000, 'time_after': 20000},
-                      'c8': {'candidate_type': 8, 'time_before': 10000, 'time_after': 20000},
-                      'c9': {'candidate_type': 9, 'time_before': 10000, 'time_after': 20000}
-                    },
+                    MLT_READOUT_MAP: dict = {},
 
                     USE_CHANNEL_FILTER: bool = True,
 
@@ -119,6 +108,23 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                     HOST="localhost",
                     DEBUG=False):
     
+    # The assignment inside the main function parantheses does not propagate
+    # to the final trigger configuration. We therefore set the MLT map here
+    # to ensure that. Should you need to change other values, do that also
+    # outside the brackets. (Below this comment)
+    MLT_READOUT_MAP: dict = {
+     'c0': {'candidate_type': 0, 'time_before': 1000, 'time_after': 1001},
+     'c1': {'candidate_type': 1, 'time_before': 1000, 'time_after': 1001},  # HSI Timing 1000 - 1001
+     'c2': {'candidate_type': 2, 'time_before': 1000, 'time_after': 1001},
+     'c3': {'candidate_type': 3, 'time_before': 1000, 'time_after': 1001},
+     'c4': {'candidate_type': 4, 'time_before': 1000, 'time_after': 1001},
+     'c5': {'candidate_type': 5, 'time_before': 1000, 'time_after': 1001},
+     'c6': {'candidate_type': 6, 'time_before': 1000, 'time_after': 1001},
+     'c7': {'candidate_type': 7, 'time_before': 1000, 'time_after': 1001},
+     'c8': {'candidate_type': 8, 'time_before': 1000, 'time_after': 1001},
+     'c9': {'candidate_type': 9, 'time_before': 1000, 'time_after': 1001}
+    }
+ 
     # Generate schema for the maker plugins on the fly in the temptypes module
     make_moo_record(ACTIVITY_CONFIG , 'ActivityConf' , 'temptypes')
     make_moo_record(CANDIDATE_CONFIG, 'CandidateConf', 'temptypes')
@@ -310,7 +316,7 @@ def get_trigger_app(CLOCK_SPEED_HZ: int = 50_000_000,
                                               buffer_timeout=MLT_BUFFER_TIMEOUT,
                                               td_out_of_timeout=MLT_SEND_TIMED_OUT_TDS,
                                               ignore_tc=MLT_IGNORE_TC,
-                                              td_readout_limit=max_td_length_ticks,
+                                              td_readout_limit=1,
                                               td_readout_map=MLT_READOUT_MAP))]
 
     mgraph = ModuleGraph(modules)


### PR DESCRIPTION
This fixes the recent issue with nightly N23-03-26, where the WIB Fragments size are larger than expected due to the new MLT configurable readout window sizes per TC type. It is coupled to the `trigger` [#198](https://github.com/DUNE-DAQ/trigger/pull/198)