### PR TITLE
Updated the ru_name that is passed to get_dqm_app in daqconf_multiru_…

### DIFF
--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+!/usr/bin/env python3
 import click
 import math
 from rich.console import Console
@@ -506,7 +506,8 @@ def cli(config, base_command_port, hardware_map_file, data_rate_slowdown_factor,
             # an underscore, but that idiosyncrasy means that we can't just give the ru_name
             # to get_dqm_app for it to use when subscribing to TimeSync messages. So, we'll
             # create a dedicated variable here *with* the underscore.
-            ru_name_with_underscore = f"ru{host}_{dro_config.card}"
+            host2=dro_config.host.replace("-","_")
+            ru_name_with_underscore = f"ru{host2}_{dro_config.card}"
 
             the_system.apps[dqm_name] = get_dqm_app(
                 DQM_IMPL=dqm.impl,

--- a/scripts/daqconf_multiru_gen
+++ b/scripts/daqconf_multiru_gen
@@ -1,4 +1,4 @@
-!/usr/bin/env python3
+#!/usr/bin/env python3
 import click
 import math
 from rich.console import Console


### PR DESCRIPTION
…gen to have underscores in the hostname.

I'm hopeful that this change will fix the problems that Giovanna and Wes have seen with the readout DQM applications at np04 complaining about invalid timestamp.s
