### PR TITLE
Added an --eth-rx-iface option to the add-eth command in dromap_editor

### DIFF
--- a/scripts/dromap_editor
+++ b/scripts/dromap_editor
@@ -130,6 +130,7 @@ def add_flx(obj, force, src_id, **kwargs):
 @click.option('--eth-rx-host')
 @click.option('--eth-rx-mac')
 @click.option('--eth-rx-ip')
+@click.option('--eth-rx-iface')
 @click.pass_obj
 def add_eth(obj, force, src_id, **kwargs):
     m = obj


### PR DESCRIPTION
I found this addition to be helpful in updating the integrationtest tools to use DRO maps, but if there are better ways to accomplish the same thing, I can certainly use one of them.