### PR TITLE
Jhancock/daqconf viewer

### DIFF
--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -6,19 +6,23 @@ import json
 import sys
 
 from rich.text import Text
+from rich.markdown import Markdown
 from difflib import context_diff, ndiff, unified_diff
 
 from textual import log, events
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Content, Container, Vertical
 from textual.widget import Widget
-from textual.widgets import Button, Header, Footer, Static, Input, Label, ListView, ListItem, Tree
+from textual.widgets import Button, Header, Footer, Static, Label, ListView, ListItem, Tree
 from textual.reactive import reactive, Reactive
-from textual.message import Message, MessageTarget
 from textual.screen import Screen
 
 auth = ("fooUsr", "barPass")
 oldconf = None
+
+class TitleBox(Static):
+    def __init__(self, title, **kwargs):
+        super().__init__(Markdown(f'# {title}'))
 
 class LabelItem(ListItem):
     def __init__(self, label: str) -> None:
@@ -39,6 +43,7 @@ class Configs(Static):
         self.set_interval(0.1, self.update_configs)
 
     def compose(self) -> ComposeResult:
+       yield TitleBox('Configuration List')
        yield ListView(LabelItem("asfas"))
 
     async def update_configs(self) -> None:
@@ -56,16 +61,22 @@ class Configs(Static):
 
     def on_list_view_selected(self, event: ListView.Selected):
         confname = event.item.label
-        versions = self.screen.query_one(Horizontal)
-        versions.new_conf(confname)
+        for v in self.screen.query(Vertical):
+            if isinstance(v, Versions):
+                v.new_conf(confname)
+                break
 
-class Versions(Horizontal):
+class Versions(Vertical):
     vlist = reactive([])
 
     def __init__(self, hostname, **kwargs):
         super().__init__(**kwargs)
         self.hostname = hostname
         self.current_conf = None
+
+    def compose(self) -> ComposeResult:
+       yield TitleBox('Available Versions')
+       yield Horizontal(id='buttonbox')
 
     def on_mount(self) -> None:
         self.set_interval(0.1, self.update_versions)
@@ -81,12 +92,13 @@ class Versions(Horizontal):
             self.vlist = r.json()['versions']          #This is a list of ints
 
     def watch_vlist(self, vlist:list[int]) -> None:
-        old_buttons = self.query(Button)
+        bb = self.query_one(Horizontal)
+        old_buttons = bb.query(Button)
         for b in old_buttons:
            b.remove()
         for v in vlist:
             b_id = 'v' + str(v)                        #An id can't be just a number for some reason
-            self.mount(Button(str(v), id=b_id, classes='vbuttons', variant='primary'))
+            bb.mount(Button(str(v), id=b_id, classes='vbuttons', variant='primary'))
 
     async def on_button_pressed (self, event: Button.Pressed) -> None:
         button_id = event.button.id
@@ -106,6 +118,7 @@ class Display(Vertical):
         self.version = None 
 
     def compose(self) -> ComposeResult:
+       yield TitleBox('Configuration Data')
        yield Tree("", id='conftree')
 
     async def get_json(self, conf, ver) -> None:
@@ -173,7 +186,8 @@ class DiffDisplay(Vertical):
         self.version = None
 
     def compose(self) -> ComposeResult:
-        yield Static(id='diffbox')
+        yield TitleBox('Diff')
+        yield Vertical(Static(id='diffbox'))
 
     async def get_json(self, conf, ver) -> None:
         self.confname = conf
@@ -208,8 +222,10 @@ class DiffDisplay(Vertical):
                         t = Text(d)
                 diff += t
 
-            box = self.query_one(Static)
-            box.update(diff)
+            for b in self.query(Static):
+              if b.id == 'diffbox':
+                  b.update(diff)
+                  break
 
     def on_button_pressed(self) -> None:
         self.remove()

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -1,5 +1,6 @@
 import asyncio
 import httpx
+import json
 
 from textual import log, events
 from textual.app import App, ComposeResult
@@ -10,42 +11,111 @@ from textual.reactive import reactive, Reactive
 from textual.message import Message, MessageTarget
 from textual.screen import Screen
 
-class ConfDisplay(Static): pass
+auth = ("fooUsr", "barPass")
+
+class LabelItem(ListItem):
+    def __init__(self, label: str) -> None:
+        super().__init__()
+        self.label = label
+
+    def compose( self ) -> ComposeResult:
+        yield Label(self.label)
 
 class Configs(Static):
+    conflist = reactive([])
+
     def __init__(self, hostname, **kwargs):
         super().__init__(**kwargs)
         self.hostname = hostname
-        self.conf_list = []
 
     def on_mount(self) -> None:
         self.set_interval(0.1, self.update_configs)
 
     def compose(self) -> ComposeResult:
-        yield Vertical (
-            ListView(
-                ListItem(Static("hello")),
-                ListItem(Static("hello2")),
-                ListItem(Static("hello3"))
-            ),
-            id="verticalconf"
-        )
-    
-    async def update_configs(self) -> None:
-        pass
-        #async with httpx.AsyncClient() as client:
-            #r = await client.post(f'{self.hostname}/nanorcrest/command', auth=auth, data=payload, timeout=60)
-        
-class Versions(Static):
-    def __init__(self, hostname, **kwargs):
-        super().__init__(**kwargs)
-        self.hostname = hostname
-        self.version_list = []  
+       yield ListView(LabelItem("asfas"))
 
-class Display(Static):
+    async def update_configs(self) -> None:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(f'{self.hostname}/listConfigs', auth=auth, timeout=60)
+        self.conflist = r.json()['configs']
+
+    def watch_conflist(self, conflist:list[str]):
+        label_list = [LabelItem(c) for c in conflist]
+        the_list = self.query_one(ListView)
+        the_list.clear()
+        for item in label_list:
+            the_list.append(item)
+
+    def on_list_view_selected(self, event: ListView.Selected):
+        '''The query gets all children of the app, then we choose Versions.'''
+        confname = event.item.label
+        versions = self.app.query_one(Horizontal)
+        versions.new_conf(confname)
+
+class Versions(Horizontal):
+    vlist = reactive([])
+
     def __init__(self, hostname, **kwargs):
         super().__init__(**kwargs)
         self.hostname = hostname
+        self.current_conf = None
+
+    def on_mount(self) -> None:
+        self.set_interval(0.1, self.update_versions)
+
+    def new_conf(self, conf) -> None:
+        self.current_conf = conf
+
+    async def update_versions(self) -> None:
+        if self.current_conf:
+            async with httpx.AsyncClient() as client:
+                payload = {'name': self.current_conf}
+                r = await client.get(f'{self.hostname}/listVersions', auth=auth, params=payload, timeout=60)
+            self.vlist = r.json()['versions']            #This is a list of ints
+
+    def watch_vlist(self, vlist:list[int]) -> None:
+        old_buttons = self.query(Button)
+        for b in old_buttons:
+           b.remove()
+        for v in vlist:
+            b_id = 'v' + str(v)    #An id can't be just a number for some reason
+            self.mount(Button(str(v), id=b_id, classes='vbuttons', variant='primary'))
+
+    #TODO make buttons smaller, and force them to be in the centre (current position is a coincidence due to the margin)
+    async def on_button_pressed (self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+        version = int(button_id[1:])
+        for v in self.app.query(Vertical):
+            if isinstance(v, Display):
+                await v.get_json(self.current_conf, version)
+                break
+
+class Display(Vertical):
+    confdata = reactive(None)
+
+    def __init__(self, hostname, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.confname = None
+        self.version = None 
+
+    def compose(self) -> ComposeResult:
+       yield Static()
+
+    async def get_json(self, conf, ver) -> None:
+        self.confname = conf
+        self.version = ver
+        if self.confname and self.version:
+            async with httpx.AsyncClient() as client:
+                payload = {'name': self.confname, 'version': self.version}
+                r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=60)
+            self.confdata = r.json()
+
+    #TODO the output could possibly be made nice with rich.print_json. It should also be able to collapse sections.
+    def watch_confdata(self, confdata:dict) -> None:
+        box = self.query_one(Static)
+        json_str = json.dumps(confdata, indent=2)
+        box.update(json_str)
 
 
 class ConfViewer(App):
@@ -54,16 +124,13 @@ class ConfViewer(App):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.hostname = "http://np04-srv-023:31011/ListConfigs"
+        self.hostname = "http://np04-srv-023:31011"
 
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""
-        yield Container(    
-            Configs(hostname=self.hostname, classes='container', id='configs'),
-            Versions(hostname=self.hostname, classes='container', id='versions'),
-            Display(hostname=self.hostname, classes='container', id='display'),
-            id = 'app-grid'
-        )
+        yield Configs(hostname=self.hostname, classes='container', id='configs')
+        yield Versions(hostname=self.hostname, classes='container', id='versions')
+        yield Display(hostname=self.hostname, classes='container', id='display')
 
         yield Header(show_clock=True)
         yield Footer()

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -4,8 +4,8 @@ import httpx
 import json
 import sys
 
-#from json_diff import Comparator
 from rich.text import Text
+from difflib import context_diff, ndiff, unified_diff
 
 from textual import log, events
 from textual.app import App, ComposeResult
@@ -17,6 +17,7 @@ from textual.message import Message, MessageTarget
 from textual.screen import Screen
 
 auth = ("fooUsr", "barPass")
+oldconf = None
 
 class LabelItem(ListItem):
     def __init__(self, label: str) -> None:
@@ -53,9 +54,8 @@ class Configs(Static):
             the_list.append(item)
 
     def on_list_view_selected(self, event: ListView.Selected):
-        '''The query gets all children of the app, then we choose Versions.'''
         confname = event.item.label
-        versions = self.app.query_one(Horizontal)
+        versions = self.screen.query_one(Horizontal)
         versions.new_conf(confname)
 
 class Versions(Horizontal):
@@ -77,22 +77,21 @@ class Versions(Horizontal):
             async with httpx.AsyncClient() as client:
                 payload = {'name': self.current_conf}
                 r = await client.get(f'{self.hostname}/listVersions', auth=auth, params=payload, timeout=60)
-            self.vlist = r.json()['versions']            #This is a list of ints
+            self.vlist = r.json()['versions']          #This is a list of ints
 
     def watch_vlist(self, vlist:list[int]) -> None:
         old_buttons = self.query(Button)
         for b in old_buttons:
            b.remove()
         for v in vlist:
-            b_id = 'v' + str(v)    #An id can't be just a number for some reason
+            b_id = 'v' + str(v)                        #An id can't be just a number for some reason
             self.mount(Button(str(v), id=b_id, classes='vbuttons', variant='primary'))
 
-    #TODO make buttons smaller, and force them to be in the centre (current position is a coincidence due to the margin)
     async def on_button_pressed (self, event: Button.Pressed) -> None:
         button_id = event.button.id
         version = int(button_id[1:])
-        for v in self.app.query(Vertical):
-            if isinstance(v, Display):
+        for v in self.screen.query(Vertical):
+            if isinstance(v, Display) or isinstance(v, DiffDisplay):
                 await v.get_json(self.current_conf, version)
                 break
 
@@ -106,8 +105,7 @@ class Display(Vertical):
         self.version = None 
 
     def compose(self) -> ComposeResult:
-       yield Tree("Root", id='conftree')
-       yield Container(Button("Get Diff", id='diff_btn', variant='primary'))
+       yield Tree("", id='conftree')
 
     async def get_json(self, conf, ver) -> None:
         self.confname = conf
@@ -154,37 +152,104 @@ class Display(Vertical):
         add_node("", node, json_data)
 
     def watch_confdata(self, confdata:dict) -> None:
-        tree = self.query_one(Tree)
-        tree.clear()
-        self.json_into_tree(tree.root, confdata)
-        tree.root.expand()
+        if confdata:
+            tree = self.query_one(Tree)
+            tree.clear()
+            self.json_into_tree(tree.root, confdata)
+            tree.root.expand()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if self.confdata:
+            self.app.mount(DiffScreen(self.hostname, self.confdata, id='diffscreen'))
+
+class DiffDisplay(Vertical):
+    confdata = reactive(None)
+
+    def __init__(self, hostname, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.confname = None
+        self.version = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(id='diffbox')
+
+    async def get_json(self, conf, ver) -> None:
+        self.confname = conf
+        self.version = ver
+        if self.confname != None and self.version != None:
+            async with httpx.AsyncClient() as client:
+                payload = {'name': self.confname, 'version': self.version}
+                r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=60)
+            self.confdata = r.json()
+
+    def watch_confdata(self, confdata:dict) -> None:
+        '''Turns the jsons into a string format with newlines, then generates a diff of the two.'''
+        if confdata:
+            a = json.dumps(oldconf, sort_keys=True, indent=4).splitlines(keepends=True)[:30]
+            b = json.dumps(confdata, sort_keys=True, indent=4).splitlines(keepends=True)[:30]
+            delta = unified_diff(a,b)
+            diff = Text()
+            for d in delta:
+                sym = d[0]
+                match sym:
+                    case '+':
+                        t = Text(d, style='green')
+                    case '-':
+                        t = Text(d, style='red')
+                    case '@':
+                        t = Text(d, style='gold1')
+                    case _:
+                        t = Text(d)
+                diff += t
+
+            box = self.query_one(Static)
+            box.update(diff)
 
     def on_button_pressed(self) -> None:
-        app.push_screen(DiffScreen())
+        self.remove()
 
 class DiffScreen(Screen):
-    pass
+    BINDINGS = [("d", "app.pop_screen", "Return")]
+    def __init__(self, hostname, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+
+    def compose(self) -> ComposeResult:
+        yield Configs(hostname=self.hostname, classes='greencontainer configs', id='diffconfigs')
+        yield Versions(hostname=self.hostname, classes='greencontainer versions', id='diffversions')
+        yield DiffDisplay(hostname=self.hostname, classes='greencontainer display', id='diffdisplay')
+
+        yield Header(show_clock=True)
+        yield Footer()
+
 
 class ConfViewer(App):
     CSS_PATH = "daqconf_viewer.css"
-    #For some reason, importing json_diff makes these two modules start printing to stdout when a HTTP request is sent.
-    #The following code supresses all non-critical messages (hopefully all of them).
-    import logging
-    logging.getLogger('asyncio').setLevel(logging.CRITICAL)
-    logging.getLogger('httpx').setLevel(logging.CRITICAL)
+    BINDINGS = [("d", "make_diff()", "Diff")]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.hostname = "http://np04-srv-023:31011"
 
+    def on_mount(self) -> None:
+        self.install_screen(DiffScreen(hostname=self.hostname), name="diff")
+
     def compose(self) -> ComposeResult:
-        """Create child widgets for the app."""
-        yield Configs(hostname=self.hostname, classes='container', id='configs')
-        yield Versions(hostname=self.hostname, classes='container', id='versions')
-        yield Display(hostname=self.hostname, classes='container', id='display')
+        yield Configs(hostname=self.hostname, classes='redcontainer configs', id='regconfigs')
+        yield Versions(hostname=self.hostname, classes='redcontainer versions', id='regversions')
+        yield Display(hostname=self.hostname, classes='redcontainer display', id='regdisplay')
 
         yield Header(show_clock=True)
         yield Footer()
+
+    def action_make_diff(self):
+        '''Saves the current config to a global variable, then pushes the diff screen.'''
+        dis = self.query_one(Display)
+        if dis.confdata != None:
+           global oldconf
+           oldconf = dis.confdata
+           self.push_screen('diff')
 
 if __name__ == "__main__":
     app = ConfViewer()

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -332,5 +332,3 @@ def start(host:str, port:str):
 
 if __name__ == "__main__":
     start()
-"http://np04-srv-023:31011"
-

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -1,12 +1,15 @@
 import asyncio
 import httpx
 import json
+import sys
+
+from rich.text import Text
 
 from textual import log, events
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Content, Container, Vertical
 from textual.widget import Widget
-from textual.widgets import Button, Header, Footer, Static, Input, Label, ListView, ListItem
+from textual.widgets import Button, Header, Footer, Static, Input, Label, ListView, ListItem, Tree
 from textual.reactive import reactive, Reactive
 from textual.message import Message, MessageTarget
 from textual.screen import Screen
@@ -37,7 +40,8 @@ class Configs(Static):
     async def update_configs(self) -> None:
         async with httpx.AsyncClient() as client:
             r = await client.get(f'{self.hostname}/listConfigs', auth=auth, timeout=60)
-        self.conflist = r.json()['configs']
+        unsorted = r.json()['configs']
+        self.conflist = sorted(unsorted, key=str.lower)
 
     def watch_conflist(self, conflist:list[str]):
         label_list = [LabelItem(c) for c in conflist]
@@ -100,27 +104,61 @@ class Display(Vertical):
         self.version = None 
 
     def compose(self) -> ComposeResult:
-       yield Static()
+       yield Tree("Root")
 
     async def get_json(self, conf, ver) -> None:
         self.confname = conf
         self.version = ver
-        if self.confname and self.version:
+        if self.confname != None and self.version != None:
             async with httpx.AsyncClient() as client:
                 payload = {'name': self.confname, 'version': self.version}
                 r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=60)
             self.confdata = r.json()
 
-    #TODO the output could possibly be made nice with rich.print_json. It should also be able to collapse sections.
+    def json_into_tree(cls, node, json_data):
+        """Takes a JSON, and puts it into the tree."""
+        from rich.highlighter import ReprHighlighter
+
+        highlighter = ReprHighlighter()
+
+        def add_node(name, node, data) -> None:
+            """Adds a node to the tree.
+            Args:
+                name (str): Name of the node.
+                node (TreeNode): Parent node.
+                data (object): Data associated with the node.
+            """
+            if isinstance(data, dict):
+                node.set_label(Text(f"{{}} {name}"))
+                for key, value in data.items():
+                    new_node = node.add("")
+                    add_node(key, new_node, value)
+            elif isinstance(data, list):
+                node.set_label(Text(f"[] {name}"))
+                for index, value in enumerate(data):
+                    new_node = node.add("")
+                    add_node(str(index), new_node, value)
+            else:
+                node.allow_expand = False
+                if name:
+                    label = Text.assemble(
+                        Text.from_markup(f"[b]{name}[/b]="), highlighter(repr(data))
+                    )
+                else:
+                    label = Text(repr(data))
+                node.set_label(label)
+
+        add_node("", node, json_data)
+
     def watch_confdata(self, confdata:dict) -> None:
-        box = self.query_one(Static)
-        json_str = json.dumps(confdata, indent=2)
-        box.update(json_str)
+        tree = self.query_one(Tree)
+        tree.clear()
+        self.json_into_tree(tree.root, confdata)
+        tree.root.expand()
 
 
 class ConfViewer(App):
     CSS_PATH = "daqconf_viewer.css"
-    #BINDINGS = [("d", "toggle_dark", "Toggle dark mode")]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import copy
+import click
 import httpx
 import json
 import sys
@@ -44,13 +45,20 @@ class Configs(Static):
 
     def compose(self) -> ComposeResult:
        yield TitleBox('Configuration List')
-       yield ListView(LabelItem("asfas"))
+       yield ListView(LabelItem("This shouldn't be visible!"))
 
     async def update_configs(self) -> None:
-        async with httpx.AsyncClient() as client:
-            r = await client.get(f'{self.hostname}/listConfigs', auth=auth, timeout=60)
-        unsorted = r.json()['configs']
-        self.conflist = sorted(unsorted, key=str.lower)
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(f'{self.hostname}/listConfigs', auth=auth, timeout=5)
+            unsorted = r.json()['configs']
+            self.conflist = sorted(unsorted, key=str.lower)
+        except Exception as e:
+            #Exiting the program mid-request causes a CancelledError: we don't want to call our function
+            #in this case, as it will not be able to find the relevent widgets.
+            if isinstance(e, asyncio.CancelledError):
+               return
+            self.display_error(f"Couldn't retrieve configs from {self.hostname}/listConfigs")
 
     def watch_conflist(self, conflist:list[str]):
         label_list = [LabelItem(c) for c in conflist]
@@ -65,6 +73,19 @@ class Configs(Static):
             if isinstance(v, Versions):
                 v.new_conf(confname)
                 break
+
+    def display_error(self, text):
+        '''If something goes wrong with getting the configs, we hijack the display to tell the user.'''
+        for v in self.screen.query(Vertical):
+            if isinstance(v, Display):
+                e_json = {'error': text}
+                v.confdata = e_json
+                break
+            if isinstance(v, DiffDisplay):
+                for s in v.query(Static):
+                    if s.id == 'diffbox':
+                       s.update(text)
+                       break
 
 class Versions(Vertical):
     vlist = reactive([])
@@ -86,10 +107,14 @@ class Versions(Vertical):
 
     async def update_versions(self) -> None:
         if self.current_conf:
-            async with httpx.AsyncClient() as client:
-                payload = {'name': self.current_conf}
-                r = await client.get(f'{self.hostname}/listVersions', auth=auth, params=payload, timeout=60)
-            self.vlist = r.json()['versions']          #This is a list of ints
+            try:
+                async with httpx.AsyncClient() as client:
+                    payload = {'name': self.current_conf}
+                    r = await client.get(f'{self.hostname}/listVersions', auth=auth, params=payload, timeout=5)
+                self.vlist = r.json()['versions']          #This is a list of ints
+            except Exception as e:
+                if isinstance(e, asyncio.CancelledError):
+                    self.display_error(f"Couldn't retrieve versions from {self.hostname}/listVersions")
 
     def watch_vlist(self, vlist:list[int]) -> None:
         bb = self.query_one(Horizontal)
@@ -108,6 +133,19 @@ class Versions(Vertical):
                 await v.get_json(self.current_conf, version)
                 break
 
+    def display_error(self, text):
+        '''If something goes wrong with getting the configs, we hijack the display to tell the user.'''
+        for v in self.screen.query(Vertical):
+            if isinstance(v, Display):
+                e_json = {'error': text}
+                v.confdata = e_json
+                break
+            if isinstance(v, DiffDisplay):
+                for s in v.query(Static):
+                    if s.id == 'diffbox':
+                       s.update(text)
+                       break
+
 class Display(Vertical):
     confdata = reactive(None)
 
@@ -115,7 +153,7 @@ class Display(Vertical):
         super().__init__(**kwargs)
         self.hostname = hostname
         self.confname = None
-        self.version = None 
+        self.version = None
 
     def compose(self) -> ComposeResult:
        yield TitleBox('Configuration Data')
@@ -125,10 +163,13 @@ class Display(Vertical):
         self.confname = conf
         self.version = ver
         if self.confname != None and self.version != None:
-            async with httpx.AsyncClient() as client:
-                payload = {'name': self.confname, 'version': self.version}
-                r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=60)
-            self.confdata = r.json()
+            try:
+                async with httpx.AsyncClient() as client:
+                    payload = {'name': self.confname, 'version': self.version}
+                    r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=5)
+                self.confdata = r.json()
+            except:
+                self.confdata = {"error": f"Couldn't retrieve the configuration at {self.hostname}/retrieveVersion (payload: {payload}"}
 
     def json_into_tree(cls, node, json_data):
         """Takes a JSON, and puts it into the tree."""
@@ -193,39 +234,48 @@ class DiffDisplay(Vertical):
         self.confname = conf
         self.version = ver
         if self.confname != None and self.version != None:
-            async with httpx.AsyncClient() as client:
-                payload = {'name': self.confname, 'version': self.version}
-                r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=60)
-            self.confdata = r.json()
+            try:
+                async with httpx.AsyncClient() as client:
+                    payload = {'name': self.confname, 'version': self.version}
+                    r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=5)
+                self.confdata = r.json()
+            except:
+                self.confdata = {"error": f"Couldn't retrieve the configuration at {self.hostname}/retrieveVersion (payload: {payload})"}
 
     async def watch_confdata(self, confdata:dict) -> None:
         '''Turns the jsons into a string format with newlines, then generates a diff of the two.'''
         if confdata:
-            j1 = copy.deepcopy(oldconf)
-            j2 = copy.deepcopy(confdata)
-            if "_id" in j1: del j1["_id"]       #We don't want to include the ID in the diff since it's always different.
-            if "_id" in j2: del j2["_id"]
-            a = json.dumps(j1, sort_keys=True, indent=4).splitlines(keepends=True)
-            b = json.dumps(j2, sort_keys=True, indent=4).splitlines(keepends=True)
-            delta = unified_diff(a,b)
-            diff = Text()
-            for d in delta:
-                sym = d[0]
-                match sym:
-                    case '+':
-                        t = Text(d, style='green')
-                    case '-':
-                        t = Text(d, style='red')
-                    case '@':
-                        t = Text(d, style='gold1')
-                    case _:
-                        t = Text(d)
-                diff += t
+            if "error" in confdata:
+                for s in self.query(Static):
+                  if s.id == 'diffbox':
+                      s.update(confdata['error'])
+                      break
+            else:
+                j1 = copy.deepcopy(oldconf)
+                j2 = copy.deepcopy(confdata)
+                if "_id" in j1: del j1["_id"]       #We don't want to include the ID in the diff since it's always different.
+                if "_id" in j2: del j2["_id"]
+                a = json.dumps(j1, sort_keys=True, indent=4).splitlines(keepends=True)
+                b = json.dumps(j2, sort_keys=True, indent=4).splitlines(keepends=True)
+                delta = unified_diff(a,b)
+                diff = Text()
+                for d in delta:
+                    sym = d[0]
+                    match sym:
+                        case '+':
+                            t = Text(d, style='green')
+                        case '-':
+                            t = Text(d, style='red')
+                        case '@':
+                            t = Text(d, style='gold1')
+                        case _:
+                            t = Text(d)
+                    diff += t
 
-            for b in self.query(Static):
-              if b.id == 'diffbox':
-                  b.update(diff)
-                  break
+                for s in self.query(Static):
+                  if s.id == 'diffbox':
+                      s.update(diff)
+                      break
 
     def on_button_pressed(self) -> None:
         self.remove()
@@ -249,9 +299,9 @@ class ConfViewer(App):
     CSS_PATH = "daqconf_viewer.css"
     BINDINGS = [("d", "make_diff()", "Diff")]
 
-    def __init__(self, **kwargs):
+    def __init__(self, host, port, **kwargs):
         super().__init__(**kwargs)
-        self.hostname = "http://np04-srv-023:31011"
+        self.hostname = f"{host}:{port}"
 
     def on_mount(self) -> None:
         self.install_screen(DiffScreen(hostname=self.hostname), name="diff")
@@ -272,6 +322,15 @@ class ConfViewer(App):
            oldconf = dis.confdata
            self.push_screen('diff')
 
-if __name__ == "__main__":
-    app = ConfViewer()
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--host', default="http://np04-srv-023", help='Machine hosting the config service')
+@click.option('--port', default="31011", help='Port that the config service listens on')
+def start(host:str, port:str):
+    app = ConfViewer(host, port)
     app.run()
+
+if __name__ == "__main__":
+    start()
+"http://np04-srv-023:31011"
+

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
+import copy
 import httpx
 import json
 import sys
@@ -183,11 +184,15 @@ class DiffDisplay(Vertical):
                 r = await client.get(f'{self.hostname}/retrieveVersion', auth=auth, params=payload, timeout=60)
             self.confdata = r.json()
 
-    def watch_confdata(self, confdata:dict) -> None:
+    async def watch_confdata(self, confdata:dict) -> None:
         '''Turns the jsons into a string format with newlines, then generates a diff of the two.'''
         if confdata:
-            a = json.dumps(oldconf, sort_keys=True, indent=4).splitlines(keepends=True)[:30]
-            b = json.dumps(confdata, sort_keys=True, indent=4).splitlines(keepends=True)[:30]
+            j1 = copy.deepcopy(oldconf)
+            j2 = copy.deepcopy(confdata)
+            if "_id" in j1: del j1["_id"]       #We don't want to include the ID in the diff since it's always different.
+            if "_id" in j2: del j2["_id"]
+            a = json.dumps(j1, sort_keys=True, indent=4).splitlines(keepends=True)
+            b = json.dumps(j2, sort_keys=True, indent=4).splitlines(keepends=True)
             delta = unified_diff(a,b)
             diff = Text()
             for d in delta:

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -1,0 +1,73 @@
+import asyncio
+import httpx
+
+from textual import log, events
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Content, Container, Vertical
+from textual.widget import Widget
+from textual.widgets import Button, Header, Footer, Static, Input, Label, ListView, ListItem
+from textual.reactive import reactive, Reactive
+from textual.message import Message, MessageTarget
+from textual.screen import Screen
+
+class ConfDisplay(Static): pass
+
+class Configs(Static):
+    def __init__(self, hostname, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.conf_list = []
+
+    def on_mount(self) -> None:
+        self.set_interval(0.1, self.update_configs)
+
+    def compose(self) -> ComposeResult:
+        yield Vertical (
+            ListView(
+                ListItem(Static("hello")),
+                ListItem(Static("hello2")),
+                ListItem(Static("hello3"))
+            ),
+            id="verticalconf"
+        )
+    
+    async def update_configs(self) -> None:
+        pass
+        #async with httpx.AsyncClient() as client:
+            #r = await client.post(f'{self.hostname}/nanorcrest/command', auth=auth, data=payload, timeout=60)
+        
+class Versions(Static):
+    def __init__(self, hostname, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.version_list = []  
+
+class Display(Static):
+    def __init__(self, hostname, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+
+
+class ConfViewer(App):
+    CSS_PATH = "daqconf_viewer.css"
+    #BINDINGS = [("d", "toggle_dark", "Toggle dark mode")]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = "http://np04-srv-023:31011/ListConfigs"
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets for the app."""
+        yield Container(    
+            Configs(hostname=self.hostname, classes='container', id='configs'),
+            Versions(hostname=self.hostname, classes='container', id='versions'),
+            Display(hostname=self.hostname, classes='container', id='display'),
+            id = 'app-grid'
+        )
+
+        yield Header(show_clock=True)
+        yield Footer()
+
+if __name__ == "__main__":
+    app = ConfViewer()
+    app.run()

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
 import asyncio
 import httpx
 import json
 import sys
 
+#from json_diff import Comparator
 from rich.text import Text
 
 from textual import log, events
@@ -104,7 +106,8 @@ class Display(Vertical):
         self.version = None 
 
     def compose(self) -> ComposeResult:
-       yield Tree("Root")
+       yield Tree("Root", id='conftree')
+       yield Container(Button("Get Diff", id='diff_btn', variant='primary'))
 
     async def get_json(self, conf, ver) -> None:
         self.confname = conf
@@ -156,9 +159,19 @@ class Display(Vertical):
         self.json_into_tree(tree.root, confdata)
         tree.root.expand()
 
+    def on_button_pressed(self) -> None:
+        app.push_screen(DiffScreen())
+
+class DiffScreen(Screen):
+    pass
 
 class ConfViewer(App):
     CSS_PATH = "daqconf_viewer.css"
+    #For some reason, importing json_diff makes these two modules start printing to stdout when a HTTP request is sent.
+    #The following code supresses all non-critical messages (hopefully all of them).
+    import logging
+    logging.getLogger('asyncio').setLevel(logging.CRITICAL)
+    logging.getLogger('httpx').setLevel(logging.CRITICAL)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -44,7 +44,7 @@ class Configs(Static):
         self.set_interval(0.1, self.update_configs)
 
     def compose(self) -> ComposeResult:
-       yield TitleBox('Configuration List')
+       yield TitleBox('Configurations')
        yield ListView(LabelItem("This shouldn't be visible!"))
 
     async def update_configs(self) -> None:
@@ -96,7 +96,7 @@ class Versions(Vertical):
         self.current_conf = None
 
     def compose(self) -> ComposeResult:
-       yield TitleBox('Available Versions')
+       yield TitleBox(f'Configuration versions')
        yield Horizontal(id='buttonbox')
 
     def on_mount(self) -> None:
@@ -156,7 +156,7 @@ class Display(Vertical):
         self.version = None
 
     def compose(self) -> ComposeResult:
-       yield TitleBox('Configuration Data')
+       yield TitleBox('Configuration data')
        yield Tree("", id='conftree')
 
     async def get_json(self, conf, ver) -> None:
@@ -297,7 +297,10 @@ class DiffScreen(Screen):
 
 class ConfViewer(App):
     CSS_PATH = "daqconf_viewer.css"
-    BINDINGS = [("d", "make_diff()", "Diff")]
+    BINDINGS = [
+        ("d", "make_diff", "Diff"),
+        ("q", "quit", "Quit"),
+    ]
 
     def __init__(self, host, port, **kwargs):
         super().__init__(**kwargs)

--- a/scripts/daqconf_viewer.css
+++ b/scripts/daqconf_viewer.css
@@ -1,0 +1,31 @@
+#app-grid {
+    layout: grid;
+    grid-size: 4 10;
+    grid-columns: 1fr;
+    grid-rows: 1fr;
+    grid-gutter: 1;
+}
+
+#configs {
+    column-span: 1;
+    row-span: 10;
+}
+
+#versions {
+    column-span: 3;
+    row-span: 2;
+}
+
+#display {
+    column-span: 3;
+    row-span: 8;
+}
+
+#verticalconf {
+    height: 20;
+}
+
+.container{
+    margin: 1;
+    border: wide red;
+}

--- a/scripts/daqconf_viewer.css
+++ b/scripts/daqconf_viewer.css
@@ -2,9 +2,13 @@
 Screen {
     layout: grid;
     layers: below above;
-    grid-size: 4 10;
-    grid-gutter: 1;
+    grid-size: 4 4;
+    grid-gutter: 0;
     height: 100%;
+}
+
+#buttonbox {
+    overflow-x: auto;
 }
 
 #conftree {
@@ -24,21 +28,20 @@ Screen {
 }
 
 .configs {
-    row-span: 10;
+    row-span: 4;
     column-span: 1;
     height: 100%;
 }
 
 .versions {
-    row-span: 2;
+    row-span: 1;
     column-span: 3;
     height: 100%;
-    overflow-x: auto;
     align-vertical: middle;
 }
 
 .display {
-    row-span: 8;
+    row-span: 4;
     column-span: 3;
     height: 100%;
     align-horizontal: center;

--- a/scripts/daqconf_viewer.css
+++ b/scripts/daqconf_viewer.css
@@ -1,24 +1,29 @@
-#app-grid {
+/* 4 columns 10 rows */
+Screen {
     layout: grid;
     grid-size: 4 10;
-    grid-columns: 1fr;
-    grid-rows: 1fr;
     grid-gutter: 1;
 }
 
 #configs {
-    column-span: 1;
     row-span: 10;
+    column-span: 1;
+    height: 100%;
 }
 
 #versions {
-    column-span: 3;
     row-span: 2;
+    column-span: 3;
+    height: 100%;
+    background: green;
 }
 
 #display {
-    column-span: 3;
     row-span: 8;
+    column-span: 3;
+    height: 100%;
+    background: purple;
+    overflow-y: auto;
 }
 
 #verticalconf {
@@ -26,6 +31,13 @@
 }
 
 .container{
-    margin: 1;
     border: wide red;
 }
+
+.vbuttons {
+    align-vertical: middle;
+    width: 5%;
+    margin: 1;
+}
+
+

--- a/scripts/daqconf_viewer.css
+++ b/scripts/daqconf_viewer.css
@@ -15,14 +15,12 @@ Screen {
     row-span: 2;
     column-span: 3;
     height: 100%;
-    background: green;
 }
 
 #display {
     row-span: 8;
     column-span: 3;
     height: 100%;
-    background: purple;
     overflow-y: auto;
 }
 

--- a/scripts/daqconf_viewer.css
+++ b/scripts/daqconf_viewer.css
@@ -15,13 +15,18 @@ Screen {
     row-span: 2;
     column-span: 3;
     height: 100%;
+    overflow-x: auto;
 }
 
 #display {
     row-span: 8;
     column-span: 3;
     height: 100%;
-    overflow-y: auto;
+    align-horizontal: center;
+}
+
+#conftree {
+    height:90%;
 }
 
 #verticalconf {

--- a/scripts/daqconf_viewer.css
+++ b/scripts/daqconf_viewer.css
@@ -1,28 +1,10 @@
 /* 4 columns 10 rows */
 Screen {
     layout: grid;
+    layers: below above;
     grid-size: 4 10;
     grid-gutter: 1;
-}
-
-#configs {
-    row-span: 10;
-    column-span: 1;
     height: 100%;
-}
-
-#versions {
-    row-span: 2;
-    column-span: 3;
-    height: 100%;
-    overflow-x: auto;
-}
-
-#display {
-    row-span: 8;
-    column-span: 3;
-    height: 100%;
-    align-horizontal: center;
 }
 
 #conftree {
@@ -33,8 +15,41 @@ Screen {
     height: 20;
 }
 
-.container{
+#diffscreen{
+    layer: above;
+    align: center middle;
+    background: cadetblue;
+    height: 100%;
+    width: 100%;
+}
+
+.configs {
+    row-span: 10;
+    column-span: 1;
+    height: 100%;
+}
+
+.versions {
+    row-span: 2;
+    column-span: 3;
+    height: 100%;
+    overflow-x: auto;
+    align-vertical: middle;
+}
+
+.display {
+    row-span: 8;
+    column-span: 3;
+    height: 100%;
+    align-horizontal: center;
+}
+
+.redcontainer{
     border: wide red;
+}
+
+.greencontainer{
+    border: wide green;
 }
 
 .vbuttons {


### PR DESCRIPTION
By running the "daqconf_viewer" command, the user can open a graphical view of all the configurations in the database. They can also look at a "diff" of two configs, which has similar formatting to the one used on github.