### PR TITLE
Put back missing comparison for det_str in readout_gen compute_data_types

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -48,7 +48,7 @@ def compute_data_types(
         fakedata_frag_type = "WIB"
         fakedata_time_tick=32
         fakedata_frame_size=472
-    elif (("HD_TPC","VD_Bottom_TPC") and stream_entry.kind=='eth' ):
+    elif (det_str in ("HD_TPC","VD_Bottom_TPC") and stream_entry.kind=='eth' ):
         fe_type = "wibeth"
         queue_frag_type="WIBEthFrame"
         fakedata_frag_type = "WIBEth"


### PR DESCRIPTION
This bug seems to have crept in as part of the DAPHNE data type changes yesterday.

I noticed it when I ran the daq-systemtest/integtest/readout_type_scan, and the TDE part of that test failed because there were no TDE_AMC fragments found.