### PR TITLE
Jhancock/daqconf viewer changes

### DIFF
--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -8,22 +8,27 @@ import sys
 
 from rich.text import Text
 from rich.markdown import Markdown
-from difflib import context_diff, ndiff, unified_diff
+from difflib import unified_diff
 
 from textual import log, events
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Content, Container, Vertical
+from textual.containers import Content, Container, Horizontal, Vertical
 from textual.widget import Widget
-from textual.widgets import Button, Header, Footer, Static, Label, ListView, ListItem, Tree
+from textual.widgets import Button, Footer, Header, Input, Label, ListItem, ListView, Static, Tree
 from textual.reactive import reactive, Reactive
 from textual.screen import Screen
 
 auth = ("fooUsr", "barPass")
 oldconf = None
+oldconfname = None
+oldconfver = None
 
 class TitleBox(Static):
     def __init__(self, title, **kwargs):
         super().__init__(Markdown(f'# {title}'))
+
+    def update(self, text):
+        super().update(Markdown(f'# {text}'))
 
 class LabelItem(ListItem):
     def __init__(self, label: str) -> None:
@@ -39,12 +44,14 @@ class Configs(Static):
     def __init__(self, hostname, **kwargs):
         super().__init__(**kwargs)
         self.hostname = hostname
+        self.term = ""
 
     def on_mount(self) -> None:
         self.set_interval(0.1, self.update_configs)
 
     def compose(self) -> ComposeResult:
        yield TitleBox('Configurations')
+       yield Input(placeholder='Search Configs')
        yield ListView(LabelItem("This shouldn't be visible!"))
 
     async def update_configs(self) -> None:
@@ -58,10 +65,27 @@ class Configs(Static):
             #in this case, as it will not be able to find the relevent widgets.
             if isinstance(e, asyncio.CancelledError):
                return
-            self.display_error(f"Couldn't retrieve configs from {self.hostname}/listConfigs")
+            self.display_error(f"Couldn't retrieve configs from {self.hostname}/listConfigs\nError: {e}")
 
     def watch_conflist(self, conflist:list[str]):
-        label_list = [LabelItem(c) for c in conflist]
+        self.display_conflist()
+
+    async def on_input_changed(self, message: Input.Changed) -> None:
+        '''This event occurs whenever the user types in the search box.'''
+        self.term = message.value
+        self.display_conflist()
+
+    def display_conflist(self) -> None:
+        '''
+        We regenerate the list whenever the actual list of configs changes, or whenever the user types in the search box.
+        #If the box is empty, don't filter, else we require that the search term is in the name
+        '''
+        if self.term == "":
+            filtered = self.conflist
+        else:
+            filtered = [name for name in self.conflist if self.term in name]
+
+        label_list = [LabelItem(f) for f in filtered]
         the_list = self.query_one(ListView)
         the_list.clear()
         for item in label_list:
@@ -118,7 +142,7 @@ class Versions(Vertical):
                 self.vlist = numlist
             except Exception as e:
                 if isinstance(e, asyncio.CancelledError):
-                    self.display_error(f"Couldn't retrieve versions from {self.hostname}/listVersions")
+                    self.display_error(f"Couldn't retrieve versions from {self.hostname}/listVersions\nError: {e}")
 
     def watch_vlist(self, vlist:list[int]) -> None:
         bb = self.query_one(Horizontal)
@@ -231,8 +255,19 @@ class DiffDisplay(Vertical):
         self.version = None
 
     def compose(self) -> ComposeResult:
-        yield TitleBox('Diff')
+        yield TitleBox("Diff")
         yield Vertical(Static(id='diffbox'))
+
+    def on_mount(self) -> None:
+        self.set_interval(0.1, self.update_title)
+
+    def update_title(self) -> None:
+        if str(self.version):   #If we didn't convert to a string, v0 would trigger the else statement
+            difftext = f"Comparing {str(oldconfname)} (v{oldconfver}) with {self.confname} (v{self.version})"
+        else:
+            difftext = f"Comparing {str(oldconfname)} (v{oldconfver}) with..."
+        title = self.query_one(TitleBox)
+        title.update(difftext)
 
     async def get_json(self, conf, ver) -> None:
         self.confname = conf
@@ -326,8 +361,8 @@ class ConfViewer(App):
         '''Saves the current config to a global variable, then pushes the diff screen.'''
         dis = self.query_one(Display)
         if dis.confdata != None:
-           global oldconf
-           oldconf = dis.confdata
+           global oldconf, oldconfname, oldconfver
+           oldconf, oldconfname, oldconfver = dis.confdata, dis.confname, dis.version 
            self.push_screen('diff')
 
     def action_flip_versions(self):

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -94,6 +94,7 @@ class Versions(Vertical):
         super().__init__(**kwargs)
         self.hostname = hostname
         self.current_conf = None
+        self.reverse = True
 
     def compose(self) -> ComposeResult:
        yield TitleBox(f'Configuration versions')
@@ -111,7 +112,10 @@ class Versions(Vertical):
                 async with httpx.AsyncClient() as client:
                     payload = {'name': self.current_conf}
                     r = await client.get(f'{self.hostname}/listVersions', auth=auth, params=payload, timeout=5)
-                self.vlist = r.json()['versions']          #This is a list of ints
+                numlist = r.json()['versions']          #This is a list of ints
+                if self.reverse:
+                    numlist.reverse()
+                self.vlist = numlist
             except Exception as e:
                 if isinstance(e, asyncio.CancelledError):
                     self.display_error(f"Couldn't retrieve versions from {self.hostname}/listVersions")
@@ -300,9 +304,10 @@ class ConfViewer(App):
     BINDINGS = [
         ("d", "make_diff", "Diff"),
         ("q", "quit", "Quit"),
+        ("v", "flip_versions", "Reverse Version Order")
     ]
 
-    def __init__(self, host, port, **kwargs):
+    def __init__(self, host, port, dir, **kwargs):
         super().__init__(**kwargs)
         self.hostname = f"{host}:{port}"
 
@@ -325,12 +330,18 @@ class ConfViewer(App):
            oldconf = dis.confdata
            self.push_screen('diff')
 
+    def action_flip_versions(self):
+        '''Tells the versions widget to display them the other way around'''
+        ver = self.screen.query_one(Versions)
+        ver.reverse = not ver.reverse
+
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--host', default="http://np04-srv-023", help='Machine hosting the config service')
 @click.option('--port', default="31011", help='Port that the config service listens on')
-def start(host:str, port:str):
-    app = ConfViewer(host, port)
+@click.option('--dir', default = "", help='Top-level directory to look for local files in')
+def start(host:str, port:str, dir:str):
+    app = ConfViewer(host, port, dir)
     app.run()
 
 if __name__ == "__main__":

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -4,20 +4,20 @@ import copy
 import click
 import httpx
 import json
-import os
 import sys
 
-from rich.text import Text
-from rich.markdown import Markdown
 from difflib import unified_diff
+from pathlib import Path
+from rich.markdown import Markdown
+from rich.text import Text
 
 from textual import log, events
 from textual.app import App, ComposeResult
 from textual.containers import Content, Container, Horizontal, Vertical
-from textual.widget import Widget
-from textual.widgets import Button, DirectoryTree, Footer, Header, Input, Label, ListItem, ListView, Static, Tree
 from textual.reactive import reactive, Reactive
 from textual.screen import Screen
+from textual.widget import Widget
+from textual.widgets import Button, DirectoryTree, Footer, Header, Input, Label, ListItem, ListView, Static, Tree
 
 auth = ("fooUsr", "barPass")
 oldconf = None
@@ -112,18 +112,34 @@ class Configs(Static):
                        s.update(text)
                        break
 
+class ShortNodeTree(DirectoryTree):
+    '''We inherit everything from the dirtree, but we want to abbreviate the top node.'''
+    def process_label(self, label):
+        '''If a node is a/b/c, just display c'''
+        if '/' in label:
+            good_label = label.split('/')[-1]
+        else:
+            good_label = label
+        if isinstance(good_label, str):
+            text_label = Text.from_markup(good_label)
+        else:
+            text_label = good_label
+        first_line = text_label.split()[0]
+        return first_line
+
 class LocalConfigs(Static):
     conflist = reactive([])
 
     def __init__(self, hostname, path, **kwargs):
         super().__init__(**kwargs)
         self.hostname = hostname
-        self.path = path
+        path_obj = Path(path)
+        self.path = str(path_obj.resolve())
 
     def compose(self) -> ComposeResult:
        yield TitleBox('Configurations')
        yield Input(placeholder='Search Configs')
-       yield DirectoryTree(self.path)
+       yield ShortNodeTree(self.path)
 
     async def on_directory_tree_file_selected(self, event: DirectoryTree.FileSelected ) -> None:
         location = event.path
@@ -386,9 +402,8 @@ class LocalDiffScreen(Screen):
         self.path = path
 
     def compose(self) -> ComposeResult:
-        yield LocalConfigs(hostname=self.hostname, path=self.path, classes='greencontainer configs', id='diffconfigs')
-        yield Versions(hostname=self.hostname, classes='greencontainer versions', id='diffversions')
-        yield DiffDisplay(hostname=self.hostname, classes='greencontainer display', id='diffdisplay')
+        yield LocalConfigs(hostname=self.hostname, path=self.path, classes='greencontainer configs', id='localdiffconfigs')
+        yield DiffDisplay(hostname=self.hostname, classes='greencontainer display', id='localdiffdisplay')
 
         yield Header(show_clock=True)
         yield Footer()
@@ -437,7 +452,6 @@ class LocalConfScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield LocalConfigs(hostname=self.hostname, path=self.path, classes='redcontainer configs', id='localconfigs')
-        yield Versions(hostname=self.hostname, classes='redcontainer versions', id='localversions')
         yield Display(hostname=self.hostname, classes='redcontainer display', id='localdisplay')
 
         yield Header(show_clock=True)

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -262,7 +262,7 @@ class DiffDisplay(Vertical):
         self.set_interval(0.1, self.update_title)
 
     def update_title(self) -> None:
-        if str(self.version):   #If we didn't convert to a string, v0 would trigger the else statement
+        if self.version != None:
             difftext = f"Comparing {str(oldconfname)} (v{oldconfver}) with {self.confname} (v{self.version})"
         else:
             difftext = f"Comparing {str(oldconfname)} (v{oldconfver}) with..."

--- a/scripts/daqconf_viewer
+++ b/scripts/daqconf_viewer
@@ -4,6 +4,7 @@ import copy
 import click
 import httpx
 import json
+import os
 import sys
 
 from rich.text import Text
@@ -14,7 +15,7 @@ from textual import log, events
 from textual.app import App, ComposeResult
 from textual.containers import Content, Container, Horizontal, Vertical
 from textual.widget import Widget
-from textual.widgets import Button, Footer, Header, Input, Label, ListItem, ListView, Static, Tree
+from textual.widgets import Button, DirectoryTree, Footer, Header, Input, Label, ListItem, ListView, Static, Tree
 from textual.reactive import reactive, Reactive
 from textual.screen import Screen
 
@@ -97,6 +98,46 @@ class Configs(Static):
             if isinstance(v, Versions):
                 v.new_conf(confname)
                 break
+
+    def display_error(self, text):
+        '''If something goes wrong with getting the configs, we hijack the display to tell the user.'''
+        for v in self.screen.query(Vertical):
+            if isinstance(v, Display):
+                e_json = {'error': text}
+                v.confdata = e_json
+                break
+            if isinstance(v, DiffDisplay):
+                for s in v.query(Static):
+                    if s.id == 'diffbox':
+                       s.update(text)
+                       break
+
+class LocalConfigs(Static):
+    conflist = reactive([])
+
+    def __init__(self, hostname, path, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.path = path
+
+    def compose(self) -> ComposeResult:
+       yield TitleBox('Configurations')
+       yield Input(placeholder='Search Configs')
+       yield DirectoryTree(self.path)
+
+    async def on_directory_tree_file_selected(self, event: DirectoryTree.FileSelected ) -> None:
+        location = event.path
+        filename = location.split('/')[-1]
+        try:
+            with open(location) as f:
+                self.current_conf = json.load(f)
+            #Look for a display to show the config to
+            for v in self.screen.query(Vertical):
+                if isinstance(v, Display) or isinstance(v, DiffDisplay):
+                    await v.get_json_local(filename, self.current_conf)
+                    break
+        except Exception as e:
+           self.display_error(f"Config at {location} is not usable\n Error: {e}")
 
     def display_error(self, text):
         '''If something goes wrong with getting the configs, we hijack the display to tell the user.'''
@@ -199,6 +240,11 @@ class Display(Vertical):
             except:
                 self.confdata = {"error": f"Couldn't retrieve the configuration at {self.hostname}/retrieveVersion (payload: {payload}"}
 
+    async def get_json_local(self, name, conf) -> None:
+        self.confname = name
+        self.version = -1
+        self.confdata = conf
+
     def json_into_tree(cls, node, json_data):
         """Takes a JSON, and puts it into the tree."""
         from rich.highlighter import ReprHighlighter
@@ -262,10 +308,14 @@ class DiffDisplay(Vertical):
         self.set_interval(0.1, self.update_title)
 
     def update_title(self) -> None:
+        #If the config is local, we set the version number to -1
+        vold = "(local)" if oldconfver == -1 else f"(v{oldconfver})"
+        vnew = "(local)" if self.version == -1 else f"(v{self.version})"
+
         if self.version != None:
-            difftext = f"Comparing {str(oldconfname)} (v{oldconfver}) with {self.confname} (v{self.version})"
+            difftext = f"Comparing {str(oldconfname)} {vold} with {self.confname} {vnew}"
         else:
-            difftext = f"Comparing {str(oldconfname)} (v{oldconfver}) with..."
+            difftext = f"Comparing {str(oldconfname)} {vold} with..."
         title = self.query_one(TitleBox)
         title.update(difftext)
 
@@ -280,6 +330,11 @@ class DiffDisplay(Vertical):
                 self.confdata = r.json()
             except:
                 self.confdata = {"error": f"Couldn't retrieve the configuration at {self.hostname}/retrieveVersion (payload: {payload})"}
+
+    async def get_json_local(self, name, conf) -> None:
+        self.confname = name
+        self.version = -1
+        self.confdata = conf
 
     async def watch_confdata(self, confdata:dict) -> None:
         '''Turns the jsons into a string format with newlines, then generates a diff of the two.'''
@@ -319,8 +374,40 @@ class DiffDisplay(Vertical):
     def on_button_pressed(self) -> None:
         self.remove()
 
+class LocalDiffScreen(Screen):
+    BINDINGS = [
+        ("l", "switch_local", "DB Files"),
+        ("d", "end_diff", "Return")
+    ]
+
+    def __init__(self, hostname, path, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.path = path
+
+    def compose(self) -> ComposeResult:
+        yield LocalConfigs(hostname=self.hostname, path=self.path, classes='greencontainer configs', id='diffconfigs')
+        yield Versions(hostname=self.hostname, classes='greencontainer versions', id='diffversions')
+        yield DiffDisplay(hostname=self.hostname, classes='greencontainer display', id='diffdisplay')
+
+        yield Header(show_clock=True)
+        yield Footer()
+
+    def action_switch_local(self) -> None:
+        self.app.pop_screen()
+        self.app.push_screen('diff')
+
+    def action_end_diff(self) -> None:
+        self.app.pop_screen()
+        self.app.push_screen('lconf')
+
+
 class DiffScreen(Screen):
-    BINDINGS = [("d", "app.pop_screen", "Return")]
+    BINDINGS = [
+        ("l", "switch_local", "Local Files"),
+        ("d", "app.pop_screen", "Return")
+    ]
+
     def __init__(self, hostname, **kwargs):
         super().__init__(**kwargs)
         self.hostname = hostname
@@ -333,21 +420,56 @@ class DiffScreen(Screen):
         yield Header(show_clock=True)
         yield Footer()
 
+    def action_switch_local(self) -> None:
+        self.app.pop_screen()
+        self.app.push_screen('ldiff')
+
+
+class LocalConfScreen(Screen):
+    BINDINGS = [
+        ("l", "app.pop_screen", "DB Files"),
+        ("d", "make_diff", "Diff")
+    ]
+    def __init__(self, hostname, path, **kwargs):
+        super().__init__(**kwargs)
+        self.hostname = hostname
+        self.path = path
+
+    def compose(self) -> ComposeResult:
+        yield LocalConfigs(hostname=self.hostname, path=self.path, classes='redcontainer configs', id='localconfigs')
+        yield Versions(hostname=self.hostname, classes='redcontainer versions', id='localversions')
+        yield Display(hostname=self.hostname, classes='redcontainer display', id='localdisplay')
+
+        yield Header(show_clock=True)
+        yield Footer()
+
+    def action_make_diff(self) -> None:
+        '''Saves the current config to a global variable, then pushes the (local) diff screen.'''
+        dis = self.query_one(Display)
+        if dis.confdata != None:
+           global oldconf, oldconfname, oldconfver
+           oldconf, oldconfname, oldconfver = dis.confdata, dis.confname, dis.version
+           self.app.pop_screen()
+           self.app.push_screen('ldiff')
 
 class ConfViewer(App):
     CSS_PATH = "daqconf_viewer.css"
     BINDINGS = [
+        ("l", "switch_local", "Local Files"),
         ("d", "make_diff", "Diff"),
+        ("v", "flip_versions", "Reverse Version Order"),
         ("q", "quit", "Quit"),
-        ("v", "flip_versions", "Reverse Version Order")
     ]
 
     def __init__(self, host, port, dir, **kwargs):
         super().__init__(**kwargs)
         self.hostname = f"{host}:{port}"
+        self.path = dir
 
     def on_mount(self) -> None:
+        self.install_screen(LocalConfScreen(hostname=self.hostname, path=self.path), name="lconf")
         self.install_screen(DiffScreen(hostname=self.hostname), name="diff")
+        self.install_screen(LocalDiffScreen(hostname=self.hostname, path=self.path), name="ldiff")
 
     def compose(self) -> ComposeResult:
         yield Configs(hostname=self.hostname, classes='redcontainer configs', id='regconfigs')
@@ -357,24 +479,33 @@ class ConfViewer(App):
         yield Header(show_clock=True)
         yield Footer()
 
-    def action_make_diff(self):
+    def action_switch_local(self) -> None:
+        self.push_screen('lconf')
+
+    def action_make_diff(self) -> None:
         '''Saves the current config to a global variable, then pushes the diff screen.'''
-        dis = self.query_one(Display)
+        dis = self.screen.query_one(Display)
         if dis.confdata != None:
            global oldconf, oldconfname, oldconfver
-           oldconf, oldconfname, oldconfver = dis.confdata, dis.confname, dis.version 
+           oldconf, oldconfname, oldconfver = dis.confdata, dis.confname, dis.version
            self.push_screen('diff')
 
-    def action_flip_versions(self):
-        '''Tells the versions widget to display them the other way around'''
-        ver = self.screen.query_one(Versions)
-        ver.reverse = not ver.reverse
+    def action_flip_versions(self) -> None:
+        '''
+        Tells the versions widget to display them the other way around.
+        If that widget doesn't exist on this scren, do nothing.
+        '''
+        try:
+            ver = self.screen.query_one(Versions)
+            ver.reverse = not ver.reverse
+        except:
+            pass
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--host', default="http://np04-srv-023", help='Machine hosting the config service')
 @click.option('--port', default="31011", help='Port that the config service listens on')
-@click.option('--dir', default = "", help='Top-level directory to look for local files in')
+@click.option('--dir', default = "./", help='Top-level directory to look for local files in')
 def start(host:str, port:str, dir:str):
     app = ConfViewer(host, port, dir)
     app.run()


### PR DESCRIPTION
In response to the feedback at the June 28th meeting, I have added some new features to the config viewer. The list of configs can be searched, and the versions can be displayed in either ascending or descending order. The diff screen tells you what two files you are comparing, and json on the local file system can be viewed/compared.