### PR TITLE
Get rid of the entrypoint

### DIFF
--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -650,17 +650,17 @@ def generate_boot(
 
     if boot_conf.disable_trace:
         del boot["exec"][daq_app_exec_name]["env"]["TRACE_FILE"]
+    boot['rte_script'] = get_rte_script()
+    # match boot_conf.k8s_rte:
+    #     case 'auto':
+    #         if (release_or_dev() == 'rel'):
+    #             boot['rte_script'] = get_rte_script()
 
-    match boot_conf.k8s_rte:
-        case 'auto':
-            if (release_or_dev() == 'rel'):
-                boot['rte_script'] = get_rte_script()
+    #     case 'release':
+    #         boot['rte_script'] = get_rte_script()
 
-        case 'release':
-            boot['rte_script'] = get_rte_script()
-
-        case 'devarea':
-            pass
+    #     case 'devarea':
+    #         pass
 
 
 
@@ -869,14 +869,17 @@ def release_or_dev():
     return 'rel'
 
 def get_rte_script():
-    from os import path
+    from os import path,getenv
+    script = ''
+    if release_or_dev() == 'rel':
+        ver = get_version()
+        releases_dir = get_releases_dir()
+        script = path.join(releases_dir, ver, 'daq_app_rte.sh')
 
-    ver = get_version()
-    releases_dir = get_releases_dir()
-
-    script = path.join(releases_dir, ver, 'daq_app_rte.sh')
+    else:
+        dbt_install_dir = getenv('DBT_INSTALL_DIR')
+        script = path.join(dbt_install_dir, 'daq_app_rte.sh')
 
     if not path.exists(script):
         raise RuntimeError(f'Couldn\'t understand where to find the rte script tentative: {script}')
-
     return script

--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -531,10 +531,10 @@ def add_k8s_app_boot_data(
 
     boot_data.update({"apps": apps_desc})
     boot_data.update({"order": boot_order})
-    if 'rte_script' in boot_data:
-        boot_data['exec']['daq_application_k8s']['cmd'] = ['daq_application']
-    else:
-        boot_data['exec']['daq_application_k8s']['cmd'] = ['/dunedaq/run/app-entrypoint.sh']
+    # if 'rte_script' in boot_data:
+    #     boot_data['exec']['daq_application_k8s']['cmd'] = ['daq_application']
+    # else:
+    #     boot_data['exec']['daq_application_k8s']['cmd'] = ['/dunedaq/run/app-entrypoint.sh']
     boot_data["exec"]["daq_application_k8s"]["image"] = image
 
 
@@ -604,7 +604,7 @@ def generate_boot(
     app_env.update({
         p:'getenv' for p in capture_paths
     })
-    
+
     app_env.update({
         v:'getenv' for v in boot_conf.capture_env_vars
     })

--- a/schema/daqconf/bootgen.jsonnet
+++ b/schema/daqconf/bootgen.jsonnet
@@ -12,8 +12,6 @@ local nc = moo.oschema.numeric_constraints;
 local cs = {
   monitoring_dest: s.enum(     "MonitoringDest", ["local", "cern", "pocket"]),
   pm_choice:       s.enum(     "PMChoice", ["k8s", "ssh"], doc="Process Manager choice: ssh or Kubernetes"),
-  rte_choice:      s.enum(     "RTEChoice", ["auto", "release", "devarea"], doc="Kubernetes DAQ application RTE choice"),
-  
 
 
   boot: s.record("boot", [
@@ -30,7 +28,6 @@ local cs = {
 
     # K8S
     s.field( "k8s_image", types.string, default="dunedaq/c8-minimal", doc="Which docker image to use"),
-    s.field( "k8s_rte", self.rte_choice, default="auto", doc="0 - Use an RTE script if not in a dev environment, 1 - Always use RTE, 2 - never use RTE"),
 
     # Connectivity Service
     s.field( "use_connectivity_service", types.flag, default=true, doc="Whether to use the ConnectivityService to manage connections"),


### PR DESCRIPTION
For K8s, since we are now mounting DBT_INSTALL_DIR, we can now directly use `daq_app_rte.sh` rather than having an entry point.
