### PR TITLE
Remove ADC generation from FrameProcessor

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -272,7 +272,8 @@ class ReadoutAppGenerator:
                             emu_frame_error_rate=0
                         ) for s in RU_DESCRIPTOR.streams],
                 use_now_as_first_data_time=cfg.emulated_data_times_start_with_now,
-                generate_periodic_adc_pattern = cfg.generate_periodic_adc_pattern,                
+                generate_periodic_adc_pattern = cfg.generate_periodic_adc_pattern,  
+                TP_rate_per_ch = cfg.emulated_TP_rate_per_ch,  
                 clock_speed_hz=self.det_cfg.clock_speed_hz,
                 queue_timeout_ms = QUEUE_POP_WAIT_MS
                 )

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -272,6 +272,7 @@ class ReadoutAppGenerator:
                             emu_frame_error_rate=0
                         ) for s in RU_DESCRIPTOR.streams],
                 use_now_as_first_data_time=cfg.emulated_data_times_start_with_now,
+                generate_periodic_adc_pattern = cfg.generate_periodic_adc_pattern,                
                 clock_speed_hz=self.det_cfg.clock_speed_hz,
                 queue_timeout_ms = QUEUE_POP_WAIT_MS
                 )

--- a/schema/daqconf/readoutgen.jsonnet
+++ b/schema/daqconf/readoutgen.jsonnet
@@ -56,6 +56,7 @@ local cs = {
     // Fake cards
     s.field( "use_fake_cards", types.flag, default=false, doc="Use fake cards"),
     s.field( "generate_periodic_adc_pattern", types.flag, default=false, doc="Generate a periodic ADC pattern inside the input data. Only when FakeCard reader is used"),     
+    s.field( "emulated_TP_rate_per_ch", types.count, default=1, doc="Rate of TPs per channel when using a periodic ADC pattern generation. Values expresses as multiples of the expected rate of 100 Hz/ch"),     
     s.field( "emulated_data_times_start_with_now", types.flag, default=false, doc="If active, the timestamp of the first emulated data frame is set to the current wallclock time"),
     s.field( "default_data_file", types.path, default='asset://?label=ProtoWIB&subsystem=readout', doc="File containing data frames to be replayed by the fake cards. Former -d. Uses the asset manager, can also be 'asset://?checksum=somelonghash', or 'file://somewhere/frames.bin' or 'frames.bin'"),
     s.field( "data_files", self.data_files, default=[], doc="Files to use by detector type"),

--- a/schema/daqconf/readoutgen.jsonnet
+++ b/schema/daqconf/readoutgen.jsonnet
@@ -55,6 +55,7 @@ local cs = {
     // s.field( "memory_limit_gb", types.count, default=64, doc="Application memory limit in GB")
     // Fake cards
     s.field( "use_fake_cards", types.flag, default=false, doc="Use fake cards"),
+    s.field( "generate_periodic_adc_pattern", types.flag, default=false, doc="Generate a periodic ADC pattern inside the input data. Only when FakeCard reader is used"),     
     s.field( "emulated_data_times_start_with_now", types.flag, default=false, doc="If active, the timestamp of the first emulated data frame is set to the current wallclock time"),
     s.field( "default_data_file", types.path, default='asset://?label=ProtoWIB&subsystem=readout', doc="File containing data frames to be replayed by the fake cards. Former -d. Uses the asset manager, can also be 'asset://?checksum=somelonghash', or 'file://somewhere/frames.bin' or 'frames.bin'"),
     s.field( "data_files", self.data_files, default=[], doc="Files to use by detector type"),


### PR DESCRIPTION
Removed ADC generation from FrameProcessors (pre-processing task) and added instead the ADC pattern generator in the SourceEmulatorModel.

A new DAQConf entry has been added for enabling the ADC pattern generation.

This fixes issues https://github.com/DUNE-DAQ/fdreadoutlibs/issues/110 and https://github.com/DUNE-DAQ/fdreadoutlibs/issues/124