### PR TITLE
daqconf split 

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -35,6 +35,8 @@ class ReadoutAppGenerator:
     """Utility class to generate readout applications"""
     
     dlh_plugin = None
+    card_override = -1 
+    numa_id = 1 # should be default_id
 
     def __init__(self, readout_cfg, det_cfg, daq_cfg):
 

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -82,6 +82,11 @@ class ReadoutAppGenerator:
         
         return list(dict.fromkeys(lcore_id_set))
 
+    ## Compute the frament types from detector infos
+    def compute_data_types(self, stream_entry):
+        raise NotImplementedError("compute_data_types must be implemented in derived classes!")
+        return [],[],[],[],[]
+
     def create_cardreader(self, RU_DESCRIPTOR, data_file_map):
 
         raise NotImplementedError("create_cardreader must be implemented in detived classes!")
@@ -467,3 +472,47 @@ class ReadoutAppGenerator:
         # All done
         return readout_app
     
+    ###
+    # Create Fake dataproducers Application
+    ###
+    def create_fake_readout_app(
+            self,
+            RU_DESCRIPTOR,
+            CLOCK_SPEED_HZ
+    ) -> App:
+        """
+        """
+        modules = []
+        queues = []
+        
+        # _, _, fakedata_fragment_type, fakedata_time_tick, fakedata_frame_size = compute_data_types(RU_DESCRIPTOR.det_id, CLOCK_SPEED_HZ, RU_DESCRIPTOR.kind)
+        
+        for stream in RU_DESCRIPTOR.streams:
+            _, _, fakedata_fragment_type, fakedata_time_tick, fakedata_frame_size = self.compute_data_types(stream)
+        
+            modules += [DAQModule(name = f"fakedataprod_{stream.src_id}",
+                                  plugin='FakeDataProd',
+                                  conf = fdp.ConfParams(
+                                      system_type = "Detector_Readout",
+                                      source_id = stream.src_id,
+                                      time_tick_diff = fakedata_time_tick,
+                                      frame_size = fakedata_frame_size,
+                                      response_delay = 0,
+                                      fragment_type = fakedata_fragment_type,
+                                  ))]
+
+        mgraph = ModuleGraph(modules, queues=queues)
+
+        for stream in RU_DESCRIPTOR.streams:
+            # Add fragment producers for fake data. This call is necessary to create the RequestReceiver instance, but we don't need the generated FragmentSender or its queues...
+            mgraph.add_fragment_producer(id = stream.src_id, subsystem = "Detector_Readout",
+                                         requests_in   = f"fakedataprod_{stream.src_id}.data_request_input_queue",
+                                         fragments_out = f"fakedataprod_{stream.src_id}.fragment_queue")
+            mgraph.add_endpoint(f"timesync_ru{RU_DESCRIPTOR.label}_{stream.src_id}", f"fakedataprod_{stream.src_id}.timesync_output",    "TimeSync",   Direction.OUT, is_pubsub=True, toposort=False)
+            
+        # Create the application
+        readout_app = App(mgraph, host=RU_DESCRIPTOR.host_name)
+        
+        # All done
+        return readout_app
+

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -30,12 +30,10 @@ from detdataformats import DetID
 # Time to wait on pop()
 QUEUE_POP_WAIT_MS = 10 # This affects stop time, as each link will wait this long before stop
 
-
 class ReadoutAppGenerator:
     """Utility class to generate readout applications"""
     
     dlh_plugin = None
-    card_override = -1 
     numa_id = 1 # should be default_id
 
     def __init__(self, readout_cfg, det_cfg, daq_cfg):
@@ -54,7 +52,6 @@ class ReadoutAppGenerator:
             lcores_excpt[(ex['host'], ex['iface'])] = ex
         self.lcores_excpt = lcores_excpt
 
-
     def get_numa_cfg(self, RU_DESCRIPTOR):
 
         cfg = self.ro_cfg
@@ -63,13 +60,11 @@ class ReadoutAppGenerator:
             numa_id = ex['numa_id']
             latency_numa = ex['latency_buffer_numa_aware']
             latency_preallocate = ex['latency_buffer_preallocation']
-            flx_card_override = ex['felix_card_id']
         except KeyError:
             numa_id = cfg.numa_config['default_id']
             latency_numa = cfg.numa_config['default_latency_numa_aware']
             latency_preallocate = cfg.numa_config['default_latency_preallocation']
-            flx_card_override = -1
-        return (numa_id, latency_numa, latency_preallocate, flx_card_override)
+        return (numa_id, latency_numa, latency_preallocate)
 
     def get_lcore_config(self, RU_DESCRIPTOR):
         cfg = self.ro_cfg
@@ -373,7 +368,7 @@ class ReadoutAppGenerator:
         Returns:
             _type_: _description_
         """
-        numa_id, latency_numa, latency_preallocate, card_override = self.get_numa_cfg(RU_DESCRIPTOR)
+        numa_id, latency_numa, latency_preallocate = self.get_numa_cfg(RU_DESCRIPTOR)
         cfg = self.ro_cfg
         TPG_ENABLED = cfg.enable_tpg
         DATA_REQUEST_TIMEOUT=data_timeout_requests

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -61,11 +61,13 @@ class ReadoutAppGenerator:
             numa_id = ex['numa_id']
             latency_numa = ex['latency_buffer_numa_aware']
             latency_preallocate = ex['latency_buffer_preallocation']
-        except KeyError:
+            flx_card_override = ex['felix_card_id']
+       except KeyError:
             numa_id = cfg.numa_config['default_id']
             latency_numa = cfg.numa_config['default_latency_numa_aware']
             latency_preallocate = cfg.numa_config['default_latency_preallocation']
-        return (numa_id, latency_numa, latency_preallocate)
+            flx_card_override = -1
+        return (numa_id, latency_numa, latency_preallocate, flx_card_override)
 
     def get_lcore_config(self, RU_DESCRIPTOR):
         cfg = self.ro_cfg
@@ -364,7 +366,7 @@ class ReadoutAppGenerator:
         Returns:
             _type_: _description_
         """
-        numa_id, latency_numa, latency_preallocate = self.get_numa_cfg(RU_DESCRIPTOR)
+        numa_id, latency_numa, latency_preallocate, card_override = self.get_numa_cfg(RU_DESCRIPTOR)
         cfg = self.ro_cfg
         TPG_ENABLED = cfg.enable_tpg
         DATA_REQUEST_TIMEOUT=data_timeout_requests

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -64,7 +64,7 @@ class ReadoutAppGenerator:
             latency_numa = ex['latency_buffer_numa_aware']
             latency_preallocate = ex['latency_buffer_preallocation']
             flx_card_override = ex['felix_card_id']
-       except KeyError:
+        except KeyError:
             numa_id = cfg.numa_config['default_id']
             latency_numa = cfg.numa_config['default_latency_numa_aware']
             latency_preallocate = cfg.numa_config['default_latency_preallocation']


### PR DESCRIPTION
There previous implementation had a bug and it was breaking the felix configuration. This issue is addressed in the following pull requests:
- `fddaqconf`: https://github.com/DUNE-DAQ/fddaqconf/pull/2
- `nddaqconf`: https://github.com/DUNE-DAQ/nddaqconf/pull/4
- `daqconf`: https://github.com/DUNE-DAQ/daqconf/pull/388
- `snbmodules`: https://github.com/DUNE-DAQ/snbmodules/pull/6

These also contain additional re-configuration required to preserve the common code in daqconf. 

All integration tests in `daq-systemtest` and `lbrulibs` are working as expected. 

In addition, the felix configuration with the option `use_fake_cards ` set to false. 

The files used are the following: 
- dro_map.json
- daqconf.json 
Both are attached in the daqconf pull request.