### PR TITLE
Making dlh queue sleep/timeouts configurable

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -121,7 +121,8 @@ class ReadoutAppGenerator:
                         plugin = self.dlh_plugin, 
                         conf = rconf.Conf(
                             readoutmodelconf= rconf.ReadoutModelConf(
-                                source_queue_timeout_ms= QUEUE_POP_WAIT_MS,
+                                source_queue_timeout_ms = cfg.source_queue_timeout_ms,
+                                source_queue_sleep_us = cfg.source_queue_sleep_us,
                                 # fake_trigger_flag=0, # default
                                 source_id =  stream.src_id,
                                 send_partial_fragment_if_available = SEND_PARTIAL_FRAGMENTS


### PR DESCRIPTION
Source queue sleep and timeout are now configurable.
Defaults set to 0 timeout, and 500 us sleep