### PR TITLE
string_to_fragment_type_value function moved to trgdataformats module

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -36,7 +36,7 @@ from daqconf.core.daqmodule import DAQModule
 from daqconf.core.conf_utils import Direction, Queue
 from daqconf.core.sourceid import TAInfo, TPInfo, TCInfo
 
-from trgdataformats import TriggerBits as trgbs
+import trgdataformats
 
 #FIXME maybe one day, triggeralgs will define schemas... for now allow a dictionary of 4byte int, 4byte floats, and strings
 moo.otypes.make_type(schema='number', dtype='i4', name='temp_integer', path='temptypes')
@@ -83,7 +83,7 @@ def get_trigger_bitwords(bitwords):
     for bitword in bitwords:
         tmp_bits = []
         for bit_name in bitword:
-            bit_value = trgbs.string_to_fragment_type_value(bit_name)
+            bit_value = trgdataformats.string_to_fragment_type_value(bit_name)
             if bit_value == 0:
                 raise RuntimeError(f'One (or more) of provided MLT trigger bitwords is unknown! Please recheck the names...')
             else:


### PR DESCRIPTION
The `string_to_fragment_type_value` was moved to `trgdataformats` module.
Thsi PR reflects the change in the `trigger_gen` code.