### PR TITLE
Added a --graceful-timeout=0 option to the connection service boot parameters

### DIFF
--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -744,6 +744,7 @@ def generate_boot(
                     "--workers=1",
                     "--worker-class=gthread",
                     f"--threads={boot_conf.connectivity_service_threads}",
+                    "--graceful-timeout=0",
                     "--timeout=0",
                     "--pid={APP_NAME}_{APP_PORT}.pid",
                     "connection-service.connection-flask:app"


### PR DESCRIPTION
…to get it (and its host gunicorn instance) to shut down in a timely way on certain computers.

I first noticed this issue when running a group of automated integration tests on the daq.fnal.gov computer with the `daqsystemtest_integtest_bundle.sh` script.  A small fraction of the time, the 2nd or 3rd or 4th test would fail to successfully start, and it would complain that a new Connectivity Service instance could not be started because one was already running.  Upon investigation, I found that Connectivity Service instances were always taking 10s of seconds to shut down when each of the individual integtests finished.  However, the observed problem of not being able to start a new instance was only happening when the same ConnSvc port number was randomly assigned to two subsequent tests.

It's straightforward to reproduce the long-shutdown behavior on daq.fnal.gov with a simple set of instructions, and I'll post those instructions in a comment on this PR.  However, there are several oddities the I observed while trying to debug this.

One oddity is that other computers don't have the same long delay.  I'll post test results in a separate comment on this PR.  I wonder if there are different OS/system settings on different computers, and that is affecting this behavior.

Another oddity is that the `ConnectivityService/gunicorn` instance responds differently to a 'kill' signal depending on whether it is started by `nanorc` or it is started by hand.

A third oddity is that the Python tools that `nanorc` uses to start/stop processes seem to indicate that the ConnSvc process has shut down when it truthfully hasn't.

Independent of all of those unexpected behaviors, when I was doing some reading about `gunicorn` shutdown behavior, I found posts about including `exit(0)` statements at the end of certain code blocks (e.g. [here](https://stackoverflow.com/questions/75664453/how-to-handle-correctly-sigterm-in-a-gunicorn-app)), and posts about the use of the `gunicorn` --graceful-timeout configuration parameter.

I experimentally determined that adding this parameter to our boot.json files in the Connectivity Service startup block with a value of zero helps get the ConnSvc to exit in a timely way on the daq.fnal.gov computer.  This PR includes that change, in case we decide that this is the best way forward, at the current time.