### PR TITLE
Configurable send partial fragments in daq conf

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -386,7 +386,6 @@ class ReadoutAppGenerator:
             SOURCEID_BROKER,
             data_file_map,
             data_timeout_requests,
-            send_partial_fragments=False
             ):
         """Generate the readout applicaton
 
@@ -428,7 +427,7 @@ class ReadoutAppGenerator:
             LATENCY_BUFFER_NUMA_AWARE=latency_numa,
             LATENCY_BUFFER_ALLOCATION_MODE=latency_preallocate,
             NUMA_ID=numa_id,
-            SEND_PARTIAL_FRAGMENTS=send_partial_fragments,
+            SEND_PARTIAL_FRAGMENTS=cfg.send_partial_fragments,
             DATA_REQUEST_TIMEOUT=DATA_REQUEST_TIMEOUT,
             RU_DESCRIPTOR=RU_DESCRIPTOR
         )

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -427,7 +427,7 @@ class ReadoutAppGenerator:
             LATENCY_BUFFER_NUMA_AWARE=latency_numa,
             LATENCY_BUFFER_ALLOCATION_MODE=latency_preallocate,
             NUMA_ID=numa_id,
-            SEND_PARTIAL_FRAGMENTS=False,
+            SEND_PARTIAL_FRAGMENTS=True,
             DATA_REQUEST_TIMEOUT=DATA_REQUEST_TIMEOUT,
             RU_DESCRIPTOR=RU_DESCRIPTOR
         )

--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -386,6 +386,7 @@ class ReadoutAppGenerator:
             SOURCEID_BROKER,
             data_file_map,
             data_timeout_requests,
+            send_partial_fragments=False
             ):
         """Generate the readout applicaton
 
@@ -427,7 +428,7 @@ class ReadoutAppGenerator:
             LATENCY_BUFFER_NUMA_AWARE=latency_numa,
             LATENCY_BUFFER_ALLOCATION_MODE=latency_preallocate,
             NUMA_ID=numa_id,
-            SEND_PARTIAL_FRAGMENTS=True,
+            SEND_PARTIAL_FRAGMENTS=send_partial_fragments,
             DATA_REQUEST_TIMEOUT=DATA_REQUEST_TIMEOUT,
             RU_DESCRIPTOR=RU_DESCRIPTOR
         )


### PR DESCRIPTION
This pull requests fixes [this issue](https://github.com/DUNE-DAQ/lbrulibs/issues/64) 
Altogether with

- https://github.com/DUNE-DAQ/daqconf/pull/414
- https://github.com/DUNE-DAQ/nddaqconf/pull/12
- https://github.com/DUNE-DAQ/lbrulibs/pull/65

In daqconf, the only change is to add an additional optional parameter in the generate(..) function, so that send_partial_fragments can be set to true. By default, the argument is set to false. Therefore, it does not affect the behaviour of other systems. This parameter can be configured from the integration tests readout options.