### PR TITLE
Added the tpset_min_latency_ticks config param to the ReadoutModelConf in readout_gen.py

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -245,6 +245,7 @@ class ReadoutAppGenerator:
                     conf = rconf.Conf(
                                 readoutmodelconf = rconf.ReadoutModelConf(
                                     source_queue_timeout_ms = QUEUE_POP_WAIT_MS,
+                                    tpset_min_latency_ticks = self.ro_cfg.tpset_min_latency_ticks,
                                     source_id = tpset_sid
                                 ),
                                 latencybufferconf = rconf.LatencyBufferConf(


### PR DESCRIPTION
…for TP data link handlers.

We now need to be able to specify a non-default value for this configuration parameter for the TPCTPRequestHandler, so this PR and a companion one in fddaqconf have the changes that allow us to do that.

[fddaqconf PR 14](https://github.com/DUNE-DAQ/fddaqconf/pull/14)