### PR TITLE
Attempted to disable the creation of TP-related modules and connectio…

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -404,7 +404,7 @@ class ReadoutAppGenerator:
         """
         numa_id, latency_numa, latency_preallocate = self.get_numa_cfg(RU_DESCRIPTOR)
         cfg = self.ro_cfg
-        TPG_ENABLED = cfg.enable_tpg
+        TPG_ENABLED = cfg.enable_tpg and RU_DESCRIPTOR.kind == "eth"
         DATA_REQUEST_TIMEOUT=data_timeout_requests
         
         modules = []

--- a/python/daqconf/core/sourceid.py
+++ b/python/daqconf/core/sourceid.py
@@ -173,7 +173,7 @@ class SourceIDBroker:
             det_id = ru_desc.det_id
             crate_id = ru_desc.streams[0].geo_id.crate_id
 
-            if tp_mode:
+            if tp_mode and ru_desc.kind == "eth":
                 tp_ru_sid = self.get_next_source_id("Trigger")
                 self.register_source_id("Trigger", tp_ru_sid, ru_desc),
 


### PR DESCRIPTION
…ns for non-WIBEth readout types

Tested at EHN1 and it seems to work. I'd request that it be included in the 4.3.0 release.

However, I'll note, that if I understand the code it's just assuming that only eth readout will be used for TP generation. At some point we may want to have DAPHNE felix-based readout also do TP generation, while still having other readout applications (e.g. CRT) not do so.

Beyond this, I think there's a bigger general issue here. It doesn't make a lot of sense to me that readout applications that are reading out different hardware should by default be configured in the same way. E.g. latency buffer sizes could well be different, TP algorithms could be different, etc. We can manage these via overrides now, but it would be nice if there could be a better way.