### PR TITLE
Only enable TPG for WIBEth and specified detector IDs

### DIFF
--- a/python/daqconf/apps/readout_gen.py
+++ b/python/daqconf/apps/readout_gen.py
@@ -404,9 +404,11 @@ class ReadoutAppGenerator:
         """
         numa_id, latency_numa, latency_preallocate = self.get_numa_cfg(RU_DESCRIPTOR)
         cfg = self.ro_cfg
-        TPG_ENABLED = cfg.enable_tpg
         DATA_REQUEST_TIMEOUT=data_timeout_requests
-        
+
+        det_str = DetID.subdetector_to_string(DetID.Subdetector(RU_DESCRIPTOR.streams[0].geo_id.det_id))
+        TPG_ENABLED = cfg.enable_tpg and RU_DESCRIPTOR.kind == "eth" and det_str in ("HD_TPC","VD_Bottom_TPC")
+
         modules = []
         queues = []
 

--- a/python/daqconf/core/sourceid.py
+++ b/python/daqconf/core/sourceid.py
@@ -11,6 +11,7 @@ from .console import console
 
 from daqdataformats import SourceID
 from detchannelmaps import *
+from detdataformats import DetID
 
 TAID = namedtuple('TAID', ['detector', 'crate'])
 TPID = namedtuple('TPID', ['detector', 'crate'])
@@ -173,7 +174,8 @@ class SourceIDBroker:
             det_id = ru_desc.det_id
             crate_id = ru_desc.streams[0].geo_id.crate_id
 
-            if tp_mode:
+            det_str = DetID.subdetector_to_string(DetID.Subdetector(ru_desc.streams[0].geo_id.det_id))
+            if tp_mode and ru_desc.kind == "eth" and det_str in ("HD_TPC","VD_Bottom_TPC"):
                 tp_ru_sid = self.get_next_source_id("Trigger")
                 self.register_source_id("Trigger", tp_ru_sid, ru_desc),
 


### PR DESCRIPTION
This PR contains code changes that are intended to be more robust than what we included in `fddaq-v4.3.0` for limitating TP generation to WIBEth readout units.  It does this by requiring the readout 'kind' to be "eth", and it also restricts the detector ID to `HD_TPC` or `VD_Bottom_TPC`.

These changes are targeted to the `fddaq-v4.4.0` release, and as such, are intended to be merged to the `production/v4` branch, once they are reviewed, approved, etc.

I've tested these changes with `daqconf.json` and `dro_map.json` files that include different types of readout, and I've verified that the regression tests in `daqsystemtest` continue to work normally.