### PR TITLE
Added an offline_data_stream config param to the detector daqconf group and the dataflow datastore parameters

### DIFF
--- a/python/daqconf/apps/dataflow_gen.py
+++ b/python/daqconf/apps/dataflow_gen.py
@@ -51,6 +51,7 @@ def get_dataflow_app(
     MAX_TRIGGER_RECORD_WINDOW = df_config.max_trigger_record_window
     TOKEN_COUNT = dataflow.token_count
     HOST=df_config.host_df
+    OFFLINE_DATA_STREAM = detector.offline_data_stream
 
 
     modules = []
@@ -78,6 +79,7 @@ def get_dataflow_app(
                                max_file_size_bytes = MAX_FILE_SIZE,
                                disable_unique_filename_suffix = False,
                                srcid_geoid_map=SRC_GEO_ID_MAP,
+                               offline_data_stream=OFFLINE_DATA_STREAM,
                                filename_parameters = hdf5ds.FileNameParams(
                                    overall_prefix = FILE_LABEL,
                                    digits_for_run_number = 6,

--- a/schema/daqconf/detectorgen.jsonnet
+++ b/schema/daqconf/detectorgen.jsonnet
@@ -17,6 +17,7 @@ local cs = {
     s.field( "op_env", types.string, default='swtest', doc="Operational environment - used for HDF5 Attribute inside the files"),
     s.field( "clock_speed_hz", types.freq, default=62500000),
     s.field( "tpc_channel_map", self.tpc_channel_map, default="PD2HDChannelMap", doc="Channel map for TPG"),
+    s.field( "offline_data_stream", types.string, default='cosmics'),
   ], doc="Global common settings"),
 
 


### PR DESCRIPTION
The changes will allow creators of DAQ configurations to specify the value of the field that we pass to Offline in the file-transfer metadata that indicates the type of data in each run.  (This field is named `data_stream` in the file-transfer metadata, and we have chosen to call it `offline_data_stream` in our code and configurations in an attempt to indicate that it is not used in the DAQ for any purpose.)

This PR is part of a Deliverable for fddaq-v4.4.0, DUNE-DAQ/daq-deliverables#126, and it is coupled with corresponding PRs in other repos, such as DUNE-DAQ/dfmodules#334 and DUNE-DAQ/hdf5libs#75.