### PR TITLE
Asztuc/trigger max tot filtering

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -232,7 +232,8 @@ def get_trigger_app(
                                       plugin = 'TPChannelFilter',
                                       conf = chfilter.Conf(channel_map_name=CHANNEL_MAP_NAME,
                                                            keep_collection=True,
-                                                           keep_induction=True))]
+                                                           keep_induction=True,
+                                                           max_time_over_threshold=10_000))]
             modules += [DAQModule(name = f'tpsettee_{link_id}',
                                   plugin = 'TPSetTee')]
 


### PR DESCRIPTION
Added TP filtering based on TP's time-over-threshold to the Trigger `TPChannelFilter` module, as discussed in https://github.com/DUNE-DAQ/ehn1-operations-issues/issues/11. The default value set to 10,000 ticks, i.e. TPs with TOT larger than 10,000 ticks will not be progressed passed `TPChannelFilter` (but will be still stored in the readout buffers, so can be retrieved as fragments). 

Full descriptions in https://github.com/DUNE-DAQ/trigger/pull/284. 
