### PR TITLE
tmp fix: update hsievents connections for individual tc makers

### DIFF
--- a/python/daqconf/apps/fake_hsi_gen.py
+++ b/python/daqconf/apps/fake_hsi_gen.py
@@ -101,7 +101,7 @@ def get_fake_hsi_app(
                                          fragments_out = f"hsi_datahandler.fragment_queue")
     mgraph.add_endpoint(f"timesync_fake_hsi", f"hsi_datahandler.timesync_output","TimeSync", Direction.OUT, is_pubsub=True, toposort=False)
 
-    mgraph.add_endpoint("hsievents", "fhsig.hsievents", "HSIEvent", Direction.OUT)
+    mgraph.add_endpoint("fake_hsievents", "fhsig.hsievents", "HSIEvent", Direction.OUT)
     mgraph.add_endpoint(None, None, data_type="TimeSync", inout=Direction.IN, is_pubsub=True)
     fake_hsi_app = App(modulegraph=mgraph, host=HOST, name="FakeHSIApp")
     

--- a/python/daqconf/apps/hsi_gen.py
+++ b/python/daqconf/apps/hsi_gen.py
@@ -126,7 +126,7 @@ def get_timing_hsi_app(
                                          fragments_out = f"hsi_datahandler.fragment_queue")
     mgraph.add_endpoint(f"timesync_timing_hsi", f"hsi_datahandler.timesync_output",  "TimeSync",  Direction.OUT, is_pubsub=True, toposort=False)
 
-    mgraph.add_endpoint("hsievents", "hsir.hsievents", "HSIEvent",    Direction.OUT)
+    mgraph.add_endpoint("dts_hsievents", "hsir.hsievents", "HSIEvent",    Direction.OUT)
     
     # dummy subscriber
     mgraph.add_endpoint(None, None, data_type="TimeSync", inout=Direction.IN, is_pubsub=True)


### PR DESCRIPTION
Temporary fix for the hsi endpoint connection names, before https://github.com/DUNE-DAQ/daqconf/pull/437 is merged in.

Tests ran:
1. Everything from https://github.com/DUNE-DAQ/integrationtest/tree/develop/python/integrationtest
2. Tried to make a configuration before and after applying this branch. 
    - Before applying the branch, I get the `ValueError: Connection with name hsievents has no consumers!.` error when running `fdaqconf_gen`.
    - After applying this branch, the error disappears.
3. Short offline run with HSI on, ran on configuration generated with this branch. Successful