### PR TITLE
Adding ttcm readout window override

### DIFF
--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -108,6 +108,31 @@ def check_mlt_roi_config(mlt_roi_conf, n_groups):
 def tc_source_present(use_hsi, use_fake_hsi, use_ctb, use_ctcm, use_rtcm, n_tp_sources):
 	return (use_hsi or use_fake_hsi or use_ctb or use_ctcm or use_rtcm or n_tp_sources)
 
+
+#===============================================================================
+def update_ttcm_map(ttcm_map,
+                    trigger_window_before_ticks,
+                    trigger_window_after_ticks
+    ):
+    """
+    Populates the readout window for TTCM hsi-TC map with the global values the
+    supplied values are -1 (default if readout window not supplied in TTCM map)
+
+    Args:
+        ttcm_map (dict): The TTCM hsi-TC map as defined in the schema.
+        trigger_window_before_ticks (int): N ticks to expand readout window before event
+        trigger_window_after_ticks (int): N ticks to expand readout window after event
+
+    Returns:
+        dict: Updated TTCM hsi-TC map
+    """
+    for entry in ttcm_map:
+        if entry['time_before'] == -1:
+            entry['time_before'] = trigger_window_before_ticks
+        if entry['time_after'] == -1:
+            entry['time_after'] = trigger_window_after_ticks
+    return ttcm_map
+
 #===============================================================================
 def get_trigger_app(
         trigger,
@@ -132,10 +157,10 @@ def get_trigger_app(
     ACTIVITY_CONFIG = trigger.trigger_activity_config
     CANDIDATE_PLUGIN = trigger.trigger_candidate_plugin
     CANDIDATE_CONFIG = trigger.trigger_candidate_config
-    TTCM_INPUT_MAP=trigger.ttcm_input_map
+    TTCM_INPUT_MAP = update_ttcm_map(trigger.ttcm_input_map,
+                                     trigger.trigger_window_before_ticks,
+                                     trigger.trigger_window_after_ticks)
     TTCM_PRESCALE=trigger.ttcm_prescale
-    TRIGGER_WINDOW_BEFORE_TICKS = trigger.trigger_window_before_ticks
-    TRIGGER_WINDOW_AFTER_TICKS = trigger.trigger_window_after_ticks
     USE_HSI_INPUT = use_hsi_input
     USE_FAKE_HSI_INPUT = use_fake_hsi_input
     USE_CTB_INPUT = use_ctb_input

--- a/schema/daqconf/triggergen.jsonnet
+++ b/schema/daqconf/triggergen.jsonnet
@@ -80,10 +80,10 @@ local cs = {
     s.field( "completeness_tolerance", types.count, default=1, doc="Maximum number of inactive queues we will tolerate."),
     s.field( "tolerate_incompleteness", types.flag, default=false, doc="Flag to tell trigger to tolerate inactive queues."),
     s.field( "ttcm_input_map", self.hsi_input_map, default=[
-      {"signal":0, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000},
-      {"signal":1, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000},
-      {"signal":2, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000},
-      {"signal":3, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000}
+      {"signal":0, "tc_type_name":"kTiming"},
+      {"signal":1, "tc_type_name":"kTiming"},
+      {"signal":2, "tc_type_name":"kTiming"},
+      {"signal":3, "tc_type_name":"kTiming"}
     ], doc="Timing trigger candidate maker accepted HSI signal map"),
     s.field( "ttcm_prescale", types.count, default=1, doc="Option to prescale TTCM TCs"),
     s.field( "ctb_prescale", types.count, default=1, doc="Option to prescale CTB TCs"),

--- a/schema/daqconf/triggergen.jsonnet
+++ b/schema/daqconf/triggergen.jsonnet
@@ -57,8 +57,8 @@ local cs = {
   hsi_input: s.record("hsi_input", [
     s.field("signal",         types.count, default=1, doc="HSI candidate maker accepted HSI signal ID"),
     s.field("tc_type_name",   self.tc_type_name, default="kTiming", doc="Name of the TC type"),
-    s.field("time_before",    self.readout_time, default=1000, doc="Time to readout before TC time [ticks]"),
-    s.field("time_after",     self.readout_time, default=1001, doc="Time to readout after TC time [ticks]"),
+    s.field("time_before",    self.readout_time, default=-1, doc="Time to readout before TC time [ticks]. -1 means override with trigger_window_before_ticks"),
+    s.field("time_after",     self.readout_time, default=-1, doc="Time to readout after TC time [ticks]. -1 means override with trigger_window_after_ticks"),
   ]),
 
   hsi_input_map: s.sequence("hsi_input_map", self.hsi_input),


### PR DESCRIPTION
A feature requested by @wesketchum  [HERE](https://dunescience.slack.com/archives/C04BATAPKK7/p1712057016688679):

When user doesn't provide any `TimingTriggerCandidateMaker` configuration, it is still being populated by the default:
```
        {"signal":0, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000},
        {"signal":1, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000},
        {"signal":2, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000},
        {"signal":3, "tc_type_name":"kTiming", "time_before":1000, "time_after":1000}
```

If the user provides the map, but leaves `"time_before"` or `"time_after"` empty for any of the TTCM/HSI signals, they will be set to `-1` by default, and then overridden with `"trigger_window_before_ticks"` and/or `"trigger_window_after_ticks"`. I couldn't figure out an easier way of overriding this in the schema, but if anyone has some ideas, please shout...

So, e.g. user-provided map:
```json
"trigger": {
      "trigger_window_after_ticks": 8000,
      "trigger_window_before_ticks": 2000,
      "ttcm_input_map": [
          {"signal": 0, "time_after": 100, "time_before": 0},
          {"signal": 1, "time_after": 100},
          {"signal": 2},
       ]
}
```

Will result in the actual map of:
```json
{
  "data": {
    "hsi_configs": [
      {"signal": 0, "tc_type_name": "kTiming", "time_after": 100, "time_before": 0},
      {"signal": 1, "tc_type_name": "kTiming", "time_after": 100, "time_before": 2000},
      {"signal": 2, "tc_type_name": "kTiming", "time_after": 8000, "time_before": 2000 }
    ],
    "prescale": 1
  },
  "match": "ttcm_fake"
},
```
The change will only be visible in `data/trigger_conf.json`, not in `config/daqconf.json`, since the override happens after default of `-1` was applied.

Tested by:
1. Everything from https://github.com/DUNE-DAQ/integrationtest/tree/develop/python/integrationtest
2. Successfully generating the few variants of the configs above with `fake_hsi`, running offline and checking with the new `HDF5LIBS_TestDumpRecord` if the TCs have correct window sizes.