### PR TITLE
New configurable for channel-time adjacency algorithm: time_tolerance

### DIFF
--- a/config/daqconf_full_config.json
+++ b/config/daqconf_full_config.json
@@ -165,6 +165,7 @@
         "trigger_activity_config": {
             "adc_threshold": 10000,
             "adj_tolerance": 4,
+            "time_tolerance": 150,
             "adjacency_threshold": 6,
             "n_channels_threshold": 8,
             "prescale": 100,

--- a/schema/daqconf/triggergen.jsonnet
+++ b/schema/daqconf/triggergen.jsonnet
@@ -32,6 +32,7 @@ local cs = {
     s.field("window_length", types.count, default=10000),
     s.field("adjacency_threshold", types.count, default=6),
     s.field("adj_tolerance", types.count, default=4),
+    s.field("time_tolerance", types.count, default=150),
     s.field("trigger_on_adc", types.flag, default=false),
     s.field("trigger_on_n_channels", types.flag, default=false),
     s.field("trigger_on_adjacency", types.flag, default=true),


### PR DESCRIPTION
- New configurable, `time_tolerance`, for the new `ChannelTimeAdjacency` algorithm.
- Value by default is 150 ticks.