### PR TITLE
Adding possibility to disable software triggering completely

### DIFF
--- a/config/daqconf_full_config.json
+++ b/config/daqconf_full_config.json
@@ -137,6 +137,7 @@
         "timing_session_name": ""
     },
     "trigger": {
+        "use_software_trigger": true,
         "host_trigger": "localhost",
         "mlt_buffer_timeout": 100,
         "mlt_ignore_tc": [],

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -170,6 +170,7 @@ def get_trigger_app(
                                      trigger.trigger_window_before_ticks,
                                      trigger.trigger_window_after_ticks)
     TTCM_PRESCALE=trigger.ttcm_prescale
+    USE_SOFTWARE_TRIGGER = trigger.use_software_trigger
     USE_HSI_INPUT = use_hsi_input
     USE_FAKE_HSI_INPUT = use_fake_hsi_input
     USE_CTB_INPUT = use_ctb_input
@@ -228,13 +229,15 @@ def get_trigger_app(
     TC_SOURCE_ID = {}
 
     for trigger_sid,conf in TRG_CONFIG.items():
-        if isinstance(conf, TPInfo):
-            TP_SOURCE_IDS[trigger_sid] = conf
-        elif isinstance(conf, TAInfo):
-            TA_SOURCE_IDS[(conf.region_id, conf.plane)] = {"source_id": trigger_sid, "conf": conf}
-        elif isinstance(conf, TCInfo):
+        # Don't fill all the source IDs if we're not using software trigger
+        print(f'trigger_sid: {trigger_sid}, conf: {conf}')
+        if USE_SOFTWARE_TRIGGER:
+            if isinstance(conf, TPInfo):
+                TP_SOURCE_IDS[trigger_sid] = conf
+            elif isinstance(conf, TAInfo):
+                TA_SOURCE_IDS[(conf.region_id, conf.plane)] = {"source_id": trigger_sid, "conf": conf}
+        if isinstance(conf, TCInfo):
             TC_SOURCE_ID = {"source_id": trigger_sid, "conf": conf}
-
        
     # Check for present of TC sources. At least 1 is required
     if not tc_source_present(USE_HSI_INPUT, USE_FAKE_HSI_INPUT, USE_CTB_INPUT, USE_CIB_INPUT, USE_CUSTOM_MAKER, USE_RANDOM_MAKER, len(TP_SOURCE_IDS)):

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -230,7 +230,6 @@ def get_trigger_app(
 
     for trigger_sid,conf in TRG_CONFIG.items():
         # Don't fill all the source IDs if we're not using software trigger
-        print(f'trigger_sid: {trigger_sid}, conf: {conf}')
         if USE_SOFTWARE_TRIGGER:
             if isinstance(conf, TPInfo):
                 TP_SOURCE_IDS[trigger_sid] = conf

--- a/schema/daqconf/triggergen.jsonnet
+++ b/schema/daqconf/triggergen.jsonnet
@@ -73,6 +73,7 @@ local cs = {
   mlt_roi_conf_map: s.sequence("mlt_roi_conf_map", self.mlt_roi_group_conf),
 
   trigger: s.record("trigger",[
+    s.field( "use_software_trigger", types.flag, default=true, doc="Option to turn off software trigger (TP->TA->TC pipeline). Standalone makers (e.g. timing) unaffected."),
     s.field( "host_trigger", types.host, default='localhost', doc='Host to run the trigger app on'),
     # trigger options
     s.field( "trigger_window_before_ticks",types.count, default=1000, doc="Trigger window before marker. Former -b"),


### PR DESCRIPTION
Added the possibility to disable software triggering completely at the config generation time, with a new option in the trigger configuration: `use_software_triger`, set to true by default (so the default behaviour is unchanged).

This means we can now run TPG, but without all the `TPChannelFilter`s, `TriggerActivityMaker`s, `TriggerCandidateMaker`s, TA buffers, zipper etc. being made. All the custom/external trigger makers (e.g. `TimingTriggerCandidateMaker`, `CIB`/`CTB`etc. trigger candidate makers) are still possible with `use_software_trigger` off.

Tested by:
1. Running systemtest: `3ru_3df_multirun_test.py`
2. Generated trigger graphs with `use_software_trigger` on and off, both with TPG on (attached below)
3. Ran both from 2. offline on one of the asset files, with output as expected: seen software triggers with flag on, and no software triggers (no TAs, no TPChannelFilters etc.) with flag set to off in grafana.

NP04 config with TPG ON and `use_software_trigger` ON:
![trigger](https://github.com/DUNE-DAQ/daqconf/assets/25038499/c286a8ae-30e8-4101-82f5-9f0935df0a2a)

NP04 config with TPG ON and `use_software_trigger` OFF:
![trigger](https://github.com/DUNE-DAQ/daqconf/assets/25038499/64b32068-1f3e-489c-88ec-d54e11bed603)


