### PR TITLE
Increase Max TCType Value.

### DIFF
--- a/schema/daqconf/triggergen.jsonnet
+++ b/schema/daqconf/triggergen.jsonnet
@@ -10,7 +10,7 @@ local s = moo.oschema.schema("dunedaq.daqconf.triggergen");
 local nc = moo.oschema.numeric_constraints;
 // A temporary schema construction context.
 local cs = {
-  tc_type:         s.number(   "TCType",        "i4", nc(minimum=0, maximum=28), doc="Number representing TC type."),
+  tc_type:         s.number(   "TCType",        "u8", nc(minimum=0, maximum=63), doc="Number representing TC type."),
   tc_type_name:     s.string(   "TCTypeName"),
   tc_types:        s.sequence( "TCTypes",       self.tc_type, doc="List of TC types"),
   tc_interval:     s.number(   "TCInterval",    "i8", nc(minimum=1, maximum=30000000000), doc="The intervals between TCs that are inserted into MLT by CTCM, in clock ticks"),


### PR DESCRIPTION
The max value of TriggerCandidate Type is now more than 28. This PR puts a new limit determined by the size limit of TCs: 63.

To test, I tried `fddaqconf_gen -c daqconf.json -m dromap.json test_config` with the following `daqconf.json` and `dromap.json` before and after this branch:
```json
{
  "boot": {
    "use_connectivity_service": true,
    "start_connectivity_service": true,
    "connectivity_service_host": "localhost",
    "connectivity_service_port": 15432
  },
  "daq_common": {
    "data_rate_slowdown_factor": 1
  },
  "detector": {
    "clock_speed_hz": 62500000
  },
  "readout": {
    "use_fake_cards": true,
    "default_data_file": "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798",
    "generate_periodic_adc_pattern": true,
    "enable_tpg": false
  },
  "trigger": {
    "mlt_merge_overlapping_tcs": false,
    "use_custom_maker": true,
    "ctcm_trigger_types": [36, 37],
    "ctcm_trigger_intervals": [62500000, 62500000],
    "mlt_use_readout_map": false
  },
  "dataflow": {
    "apps": [ { "app_name": "dataflow0" } ],
    "enable_tpset_writing": false,
    "token_count": 20
  },
  "hsi": {
    "random_trigger_rate_hz": 1.0
  }
}
```

```json
[
    {
        "src_id": 100,
        "geo_id": {
            "det_id": 3,
            "crate_id": 1,
            "slot_id": 0,
            "stream_id": 0
        },
        "kind": "eth",
        "parameters": {
            "protocol": "udp",
            "mode": "fix_rate",
            "rx_iface": 0,
            "rx_host": "localhost",
            "rx_pcie_dev": "0000:00:00.0",
            "rx_mac": "00:00:00:00:00:00",
            "rx_ip": "0.0.0.0",
            "tx_host": "localhost",
            "tx_mac": "00:00:00:00:00:00",
            "tx_ip": "0.0.0.0"
        }
    },
    {
        "src_id": 101,
        "geo_id": {
            "det_id": 3,
            "crate_id": 1,
            "slot_id": 0,
            "stream_id": 1
        },
        "kind": "eth",
        "parameters": {
            "protocol": "udp",
            "mode": "fix_rate",
            "rx_iface": 0,
            "rx_host": "localhost",
            "rx_pcie_dev": "0000:00:00.0",
            "rx_mac": "00:00:00:00:00:00",
            "rx_ip": "0.0.0.0",
            "tx_host": "localhost",
            "tx_mac": "00:00:00:00:00:00",
            "tx_ip": "0.0.0.0"
        }
    }
]
```

Before this branch, `fddaqconf_gen` would complain about the max TC type value. After this branch, config generation completes without complaint.