### PR TITLE
Adding opmon interval as a boot option

### DIFF
--- a/python/daqconf/core/conf_utils.py
+++ b/python/daqconf/core/conf_utils.py
@@ -676,6 +676,8 @@ def generate_boot(
         "exec": daq_app_specs
     }
 
+    boot["env"]["DUNEDAQ_OPMON_INTERVAL"] = boot_conf.opmon_interval
+    
     if use_kafka:
         boot["env"]["DUNEDAQ_ERS_STREAM_LIBS"] = "erskafka"
 

--- a/schema/daqconf/bootgen.jsonnet
+++ b/schema/daqconf/bootgen.jsonnet
@@ -23,6 +23,7 @@ local cs = {
     s.field( "capture_env_vars", types.strings, default=['TIMING_SHARE', 'DETCHANNELMAPS_SHARE'], doc="List of variables to capture from the environment"),
     s.field( "disable_trace", types.flag, false, doc="Do not enable TRACE (default TRACE_FILE is /tmp/trace_buffer_${HOSTNAME}_${USER})"),
     s.field( "opmon_impl", self.monitoring_dest, default='local', doc="Info collector service implementation to use"),
+    s.field( "opmon_interval", types.count, default=10, doc="Interval of monitoring rage in seconds"),
     s.field( "ers_impl", self.monitoring_dest, default='local', doc="ERS destination (Kafka used for cern and pocket)"),
     s.field( "pocket_url", types.host, default='127.0.0.1', doc="URL for connecting to Pocket services"),
     s.field( "process_manager", self.pm_choice, default="ssh", doc="Choice of process manager"),


### PR DESCRIPTION
This adds the opmon interval at the boot.json. The default is the same as before so there is no change in behaviour. 

This is requested by CTB people to correctly see the spill structure in protoDUNE. 