### PR TITLE
Allowing ADCSimpleWindow user-provided tc-type output

### DIFF
--- a/config/daqconf_full_config.json
+++ b/config/daqconf_full_config.json
@@ -195,7 +195,8 @@
             "trigger_on_n_channels": false,
             "window_length": 10000,
             "bundle_size": 100,
-            "max_tp_count": 1000
+            "max_tp_count": 1000,
+            "tc_type_name": "kUnknown"
         },
         "trigger_candidate_plugin": "TriggerCandidateMakerPrescalePlugin",
         "trigger_rate_hz": 1.0,

--- a/python/daqconf/apps/trigger_gen.py
+++ b/python/daqconf/apps/trigger_gen.py
@@ -517,7 +517,7 @@ def get_trigger_app(
         ## # Use connect_modules to connect up the Tees to the buffers/MLT,
         ## # as manually adding Queues doesn't give the desired behaviour
 
-        for region_id in TA_SOURCE_IDS.keys():
+        for region_id, plane in TA_SOURCE_IDS.keys():
             # Send the output of the new TPSetTee module to each of the activity makers
             if(num_algs > 1):
                 for j in range(num_algs):

--- a/schema/daqconf/triggergen.jsonnet
+++ b/schema/daqconf/triggergen.jsonnet
@@ -31,6 +31,7 @@ local cs = {
   trigger_algo_config: s.record("trigger_algo_config", [
     s.field("prescale", types.count, default=100),
     s.field("window_length", types.count, default=10000),
+    s.field("tc_type_name",   self.tc_type_name, default="kUnknown"),
     s.field("adjacency_threshold", types.count, default=6),
     s.field("adj_tolerance", types.count, default=4),
     s.field("trigger_on_adc", types.flag, default=false),


### PR DESCRIPTION
This PR allows the ADCSimpleWindow to produce TC with any user-provided TC-type (something that in v5 we will probably want all algorithms to be capable of), and fixes a small bug for creating configuration with multiple triggering algorithms per subdetector. Full description in https://github.com/DUNE-DAQ/triggeralgs/pull/75