### PR TITLE
Instead of assuming that all VirtualHost entries in the configuration

### DIFF
--- a/python/daqconf/generate_readoutOKS.py
+++ b/python/daqconf/generate_readoutOKS.py
@@ -1,6 +1,5 @@
 from calendar import day_abbr
 from curses import qiflush
-from re import I
 import conffwk
 import os
 import glob

--- a/python/daqconf/generate_readoutOKS.py
+++ b/python/daqconf/generate_readoutOKS.py
@@ -1,5 +1,6 @@
 from calendar import day_abbr
 from curses import qiflush
+from re import I
 import conffwk
 import os
 import glob
@@ -14,6 +15,7 @@ def generate_readout(
     session,
     emulated_file_name="asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e",
     tpg_enabled=True,
+    hosts_to_use=[],
 ):
     """Simple script to create an OKS configuration file for all
   ReadoutApplications defined in a readout map.
@@ -197,18 +199,23 @@ def generate_readout(
             qrules.append(db.get_dal(class_name="QueueConnectionRule", uid=rule))
 
     hosts = []
-    for vhost in db.get_dals(class_name="VirtualHost"):
-        hosts.append(vhost.id)
-        if vhost.id == "vlocalhost":
-            host = vhost
-    if "vlocalhost" not in hosts:
-        cpus = dal.ProcessingResource("cpus", cpu_cores=[0, 1, 2, 3])
-        db.update_dal(cpus)
-        phdal = dal.PhysicalHost("localhost", contains=[cpus])
-        db.update_dal(phdal)
-        host = dal.VirtualHost("vlocalhost", runs_on=phdal, uses=[cpus])
-        db.update_dal(host)
-        hosts.append("vlocalhost")
+    if len(hosts_to_use) == 0:
+        for vhost in db.get_dals(class_name="VirtualHost"):
+            if vhost.id == "vlocalhost":
+                hosts.append(vhost.id)
+        if "vlocalhost" not in hosts:
+            cpus = dal.ProcessingResource("cpus", cpu_cores=[0, 1, 2, 3])
+            db.update_dal(cpus)
+            phdal = dal.PhysicalHost("localhost", contains=[cpus])
+            db.update_dal(phdal)
+            host = dal.VirtualHost("vlocalhost", runs_on=phdal, uses=[cpus])
+            db.update_dal(host)
+            hosts.append("vlocalhost")
+    else:
+        for vhost in db.get_dals(class_name="VirtualHost"):
+            if vhost.id in hosts_to_use:
+                hosts.append(vhost.id)
+    assert(len(hosts) > 0)
 
     rohw = dal.RoHwConfig(f"rohw-{detector_connections[0].id}")
     db.update_dal(rohw)

--- a/scripts/generate_readoutOKS
+++ b/scripts/generate_readoutOKS
@@ -13,9 +13,10 @@ from daqconf.generate_readoutOKS import generate_readout
               help='Enable generation of a Segment object containing the ReadoutApplications')
 @click.option('--session', is_flag=True,
               help='Enable generation of a Session object containing the generated Segment (implies --segment)')
+@click.option('--host', multiple=True, help='Hosts that can run readout applications. Should match a declared VirtualHost in the included configuration files. Specify this option multiple times to set up ReadoutApplications on multiple hosts.')
 @click.argument('readoutmap')
 @click.argument('oksfile')
-def generate(readoutmap, oksfile, include, segment, session):
+def generate(readoutmap, oksfile, include, segment, session, host):
   """Simple script to create an OKS configuration file for all
   ReadoutApplications defined in a readout map.
 
@@ -45,7 +46,7 @@ def generate(readoutmap, oksfile, include, segment, session):
 
   """
 
-  generate_readout(readoutmap, oksfile, include, segment, session)
+  generate_readout(readoutmap, oksfile, include, segment, session, hosts_to_use=host)
 
 if __name__ == '__main__':
   generate()


### PR DESCRIPTION
are available for running readout applications, take an array of allowed hosts as a parameter, putting all readout apps on localhost if none are specified.