### PR TITLE
Removed the tc-maker-1 app from generate_trigger, for now…

### DIFF
--- a/python/daqconf/generate_triggerOKS.py
+++ b/python/daqconf/generate_triggerOKS.py
@@ -77,7 +77,6 @@ def generate_trigger(
     # Services
     mlt_control = db.get_dal(class_name="Service", uid="mlt_control")
     dataRequests = db.get_dal(class_name="Service", uid="dataRequests")
-    tc_maker_control = db.get_dal(class_name="Service", uid="tc-maker-1_control")
     triggerActivities = db.get_dal(class_name="Service", uid="triggerActivities")
     triggerCandidates = db.get_dal(class_name="Service", uid="triggerCandidates")
     triggerInhibits = db.get_dal(class_name="Service", uid="triggerInhibits")
@@ -141,20 +140,6 @@ def generate_trigger(
     ta_subscriber = db.get_dal(class_name="DataReaderConf", uid="ta-subscriber-1")
     ta_handler = db.get_dal(class_name="DataHandlerConf", uid="def-ta-handler")
 
-    tcmaker = dal.TriggerApplication(
-        "tc-maker-1",
-        runs_on=host,
-        application_name="daq_application",
-        exposes_service=[tc_maker_control, triggerActivities, dataRequests],
-        source_id=tc_source_id,
-        queue_rules=tapp_qrules,
-        network_rules=tapp_netrules,
-        opmon_conf=opmon_conf,
-        data_subscriber=ta_subscriber,
-        trigger_inputs_handler=ta_handler,
-    )
-    db.update_dal(tcmaker)
-
     if segment or session != "":
         fsm = db.get_dal(class_name="FSMconfiguration", uid="FSMconfiguration_noAction")
         controller_service = dal.Service(
@@ -172,7 +157,7 @@ def generate_trigger(
         db.update_dal(controller)
 
         seg = dal.Segment(
-            f"trg-segment", controller=controller, applications=[mlt, tcmaker]
+            f"trg-segment", controller=controller, applications=[mlt]
         )
         db.update_dal(seg)
 


### PR DESCRIPTION
…since it does not seem to be needed, and it causes spurious warning messages in the minimal_system_quick_test.py log files.   

I've made tentative changes in this repo and in the daqsystemtest repo (same branch name).  I've confirmed that the minimal_system_quick_test.py continues to work with these changes.

The changes that I've made here may be too brute-force.  I can imagine that we might want an option to the generate_trigger(OKS) function that specifies whether the tc-maker-1 app should be included or now.  Also, it would be great for someone to confirm that I've sliced out the right amount of tc-maker-1-related lines (not too much or too little).