### PR TITLE
Configuration inspector

### DIFF
--- a/python/daqconf/session.py
+++ b/python/daqconf/session.py
@@ -1,0 +1,96 @@
+import conffwk
+
+def get_segment_apps(segment):
+    apps = []
+
+    for ss in segment.segments:
+        apps += get_segment_apps(ss)
+
+    for aa in segment.applications:
+        apps.append(aa)
+
+    return apps
+
+
+def get_session_apps(confdb, session_name=""):
+    """Get the apps defined in the given session"""
+    if session_name == "":
+        session_dals = confdb.get_dals(class_name="Session")
+        if len(session_dals) == 0:
+            print(f"Error could not find any Session in file {confdb.databases}")
+            return
+        session = session_dals[0]
+    else:
+        try:
+            session = confdb.get_dal("Session", session_name)
+        except:
+            print(f"Error could not find Session {session_name} in file {confdb.databases}")
+            return
+
+    segment = session.segment
+
+    return get_segment_apps(segment)
+
+
+def get_apps_in_any_session(confdb):
+
+    output = {}
+    session_dals = confdb.get_dals(class_name="Session")
+    if len(session_dals) == 0:
+        print(f"Error could not find any Session in file {confdb.databases}")
+        return {}
+
+    for session in session_dals:
+        segment = session.segment
+        output[session.id] = get_segment_apps(segment)
+
+    return output
+
+
+
+def enable_resource_in_session(db, session_name: str, resource: list[str], disable: bool):
+    """Script to enable or disable (-d) Resources from the first Session of the
+    specified OKS database file"""
+    if session_name == "":
+        session_dals = db.get_dals(class_name="Session")
+        if len(session_dals) == 0:
+            print(f"Error could not find any Session in file {db.databases}")
+            return
+        session = session_dals[0]
+    else:
+        try:
+            session = db.get_dal("Session", session_name)
+        except:
+            print(f"Error could not find Session {session_name} in file {db.databases}")
+            return
+        
+    disabled = session.disabled
+    for res in resource:
+        try:
+            res_dal = db.get_dal("ResourceBase", res)
+        except:
+            print(f"Error could not find Resource {res} in file {db.databases}")
+            continue
+
+        if disable:
+            if res_dal in disabled:
+                print(
+                    f"{res} is already in disabled relationship of Session {session.id}"
+                )
+            else:
+                # Add to the Segment's disabled list
+                print(f"Adding {res} to disabled relationship of Session {session.id}")
+                disabled.append(res_dal)
+        else:
+            if res_dal not in disabled:
+                print(f"{res} is not in disabled relationship of Session {session.id}")
+            else:
+                # Remove from the Segments disabled list
+                print(
+                    f"Removing {res} from disabled relationship of Session {session.id}"
+                )
+                disabled.remove(res_dal)
+    session.disabled = disabled
+    db.update_dal(session)
+    db.commit()
+

--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -192,7 +192,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.pass_obj
 def cli(obj, interactive, config_file):
     """
-    A collection of helper commands to inspect dunedaq OKS databases and objects
+    An utility script to develop ways to meaningfully inspect and 
+    visualise DAQ configuration databases and to prototype validation algorithms.
+    
     """
     cfg = conffwk.Configuration(f"oksconflibs:{config_file}")
     obj.cfg = cfg
@@ -206,7 +208,31 @@ def cli(obj, interactive, config_file):
 @click.pass_obj
 def show_sessions(obj, show_file_paths):
     """
-    Show high level information about the sessions from the configuration database
+    Show details of each session available in the configuration database
+
+    For each session found in the the database, `show-session` displays:
+
+    \b
+    - The high-level session view, including segments, controllers and applications as
+      hierarchical tree.
+      ID and Class are shown for applications and controllers, along with their host and services (open ports)
+      The icon in front of segments and appliations indicate the enable/disable.
+
+      Optionally, it displays the path of the the database file where the object is define 
+
+    \b
+      Legend
+      ------
+        ✅ : Resource enabled
+        ❌ : Resource directly disabled (listed in the Session disable list)
+        ⭕️ : Resource indirectly disabled by algorithm
+
+    - The summary of session objects, including the count of referenced objects, the list of directly
+      disabled objects and the list of all disabled objects (directly or indirectly)
+    
+    - The session environment table.
+
+
     """
     from rich.highlighter import ReprHighlighter
     rh = ReprHighlighter()
@@ -233,7 +259,7 @@ def show_sessions(obj, show_file_paths):
 
         tree.add(make_segment_tree(cfg, s.segment, s, show_file_paths))
 
-        t = Table("body", title='Session Tree', show_header=False, expand=True)
+        t = Table("body", title=f'{s.id} tree', show_header=False, expand=True)
         t.add_row(tree)
         grid.add_row(t)
         
@@ -249,7 +275,7 @@ def show_sessions(obj, show_file_paths):
 
 
 
-        t = Table(title=s.id, show_header=False, expand=True)
+        t = Table(title=f"{s.id} objects", show_header=False, expand=True)
         t.add_column('name')
         t.add_column('value')
 
@@ -272,13 +298,13 @@ def show_sessions(obj, show_file_paths):
 
             env_var = sorted(env_objs, key=lambda x: x.id)
 
-            t = Table(title="Environment", show_header=False,  expand=True)
+            t = Table(title=f"{s.id} environment", show_header=False,  expand=True)
             t.add_column('name')
             t.add_column('value')
             for e in env_var:
                 if 'Variable' not in e.oksTypes():
                     continue
-                t.add_row(e.id, e.value)
+                t.add_row(e.id, rh(e.value))
             # print(t)
             grid.add_row(t)
             print(grid)
@@ -304,11 +330,11 @@ def list_classes(obj, show_derived):
         table.add_row(k, rh(str([o.UID() for o in cfg.get_objs(k) if (o.class_name() == k or show_derived)])))
     print(table)
 
-@cli.command(short_help="Show properties of objects forma class")
+@cli.command(short_help="Show properties of objects belonging to a class")
 @click.argument('klass')
-@click.option('-v/-h','--vertical/--horizontal', "vtable", default=True, help="Vertical or horizontal orientation")
+@click.option('-v/-h','--vertical/--horizontal', "vtable", default=True, help="Toggle vertical or horizontal orientation")
 @click.pass_obj
-def show_obj_of_class(obj, klass, vtable):
+def show_objects_of_class(obj, klass, vtable):
     """
     Show attributes and relationships of all objects in the database belonging to KLASS
     """
@@ -375,14 +401,28 @@ def show_obj_of_class(obj, klass, vtable):
 @click.argument('uid', type=click.UNPROCESSED, callback=validate_oks_uid, default=None)
 @click.option('+a/-a','--show-attributes/--hide-attributes', "show_attrs", default=True, help="Show/Hide attributes")
 @click.option('-l','--level', "level", type=int, default=None, help="Recursion level in the object tree")
-@click.option('-p','--path', "path", default=None, help="Path within the object relationships to visualise")
+@click.option('-f','--focus', "focus_path", default=None, help="Path within the object relationships to visualise")
 @click.pass_obj
-def show_object_tree(obj, uid, show_attrs, path, level):
+def show_object_tree(obj, uid, show_attrs, focus_path, level):
     """
     Show the relationship tree of the OKS object with identifier UID.
 
-    The format of UID is <object name>@<class>
+    UID is the unique object identifier in the database, composed by object name and class name. 
+    The UID format argument is <object name>@<class>.
+
+    Starting from the selected object, attributes and objects refererd by relationships are shown recursively as hierarchical tree.
+    By default the command recursively crawls through relationship without limits. The recursion level can be limited with the corresponding optional parameter (see below).
+    In case focussing on a relationship branch is helpful, the focus path option (see below for details) allows to specify the branch to focus on, starting trom the top object.
+    The focus path syntax combines relationhsip and object names, using `.` separators, and `[]` to select a single item in multi-value relatiosnips.
+    The structure of the focus path specifier is `<relationship>[<optional object name>].<relationship>[<optional object name>]`.
+    Note: specifiying the object name is required 
+
+    \b
+    `show-object-tree` subcommand example:
+        Focus on the uses.dfhw-01 relationship of df-03@DFApplication and limit the output to 5 levels below df-03
+        `show-object-tree df-03@DFApplication  -f network_rules[td-trb-net-rule].descriptor -l 5`
     """
+    import re
     id, klass = uid
 
     from rich.highlighter import ReprHighlighter
@@ -395,14 +435,20 @@ def show_object_tree(obj, uid, show_attrs, path, level):
         raise SystemExit(-1)
 
     
-    path = path.split('.') if path is not None else []
+    focus_path = focus_path.split('.') if focus_path is not None else []
+    re_index = re.compile('([\w-]*)(\[([\w-]*)\])?')
+    path = []
+    for p in focus_path:
+        m = re_index.match(p)
+        if m is None:
+            raise RuntimeError("Incorrect systax of path specifier p")
+        rel,_,name = m.groups()
+        path.append((rel, name))
 
     try:
         do = cfg.get_dal(klass, id)
     except RuntimeError as e:
         raise click.BadArgumentUsage(f"Object '{id}' does not exist")
-
-
 
     def make_obj_tree(dal_obj, show_attrs, path=[], level=None):
         tree = Tree(f"[green]{dal_obj.id}[/green][magenta]@{dal_obj.className()}[/magenta]")
@@ -412,13 +458,11 @@ def show_object_tree(obj, uid, show_attrs, path, level):
         attrs = cfg.attributes(dal_obj.className(), True)
         rels = cfg.relations(dal_obj.className(), True)
 
-        rel_sel = None
+        rel_sel, obj_sel = None, None
         if path:
-            if path[0] not in rels:
-                raise click.BadArgumentUsage(f"Object '{path[0]}' does not exist in {dal_obj.id}")
-            else:
-                rel_sel = path[0]
-                path = path[1:]
+            rel_sel, obj_sel = path[0]
+            if rel_sel not in rels:
+                raise click.BadArgumentUsage(f"Object '{rel_sel}' does not exist in {dal_obj.id}")
 
         if show_attrs:
             for a in attrs:
@@ -438,7 +482,8 @@ def show_object_tree(obj, uid, show_attrs, path, level):
                 rel_val = [rel_val]
 
             for val in rel_val:
-                if path and val.id != path[0]:
+
+                if obj_sel and val.id != obj_sel:
                     continue
                 if val is None:
                     continue

--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -9,6 +9,9 @@ import click
 import conffwk
 
 def start_ipython(loc):
+    """
+    Usage: start_ipython(locals())
+    """
     try:
         locals().update(loc)
         import IPython
@@ -138,7 +141,7 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
 
     c = segment.controller
     path = f"[blue]{cfg.get_obj(c.className(), c.id).contained_in()}[/blue]" if show_path else ""
-    ports = ', '.join([f'{svc.port}([orange1]{svc.protocol}[/orange1])' for svc in c.exposes_service ])
+    ports = ', '.join([f'{svc.port}([orange1]{svc.id}[/orange1])' for svc in c.exposes_service ])
     host = f"[medium_purple1]{c.runs_on.runs_on.id}[/medium_purple1]"
     tree.add(f"[cyan]controller[/cyan]: [green]{c.id}[/green][magenta]@{c.className()}[/magenta] on {host} [{ports}] {path}")
 
@@ -150,7 +153,7 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
                 continue
 
             path = f"[blue]{cfg.get_obj(a.className(), a.id).contained_in()}[/blue]" if show_path else ""
-            ports = ', '.join([f'{svc.port}([orange1]{svc.protocol}[/orange1])' for svc in c.exposes_service ])
+            ports = ', '.join([f'{svc.port}([orange1]{svc.id}[/orange1])' for svc in a.exposes_service ])
             host = f"[medium_purple1]{a.runs_on.runs_on.id}[/medium_purple1]"
             enabled = is_enabled(cfg, session, a) if session else None
 
@@ -528,9 +531,9 @@ def show_object_tree(obj, uid, show_attrs, focus_path, level):
 @click.pass_obj
 def validate_detstreams(obj):
     """
-    Validates detector datastreams in a database.
+    Performs basic validation of detector datastreams in a database.
 
-    The command checks the collection of all detastreans in the database for uiniqueness.
+    It checks the collection of all detastreans in the database for uiniqueness.
     It also checks that all geo_ids references by detecor streams are unique.
     """
     from rich.highlighter import ReprHighlighter
@@ -557,6 +560,7 @@ def validate_detstreams(obj):
     streams = sorted(streams, key=lambda x: x.source_id)
 
 
+    # Print an expanded detector stream table, including geo_id attributes
     table = Table(title='DetectorStreams')
     table.add_column('id')
     table.add_column('status')
@@ -586,7 +590,7 @@ def validate_detstreams(obj):
     if strm_duplicates:
         print(f"[yellow]WARNING: found duplicates in detector streams {strm_duplicates}[/yellow]")
     else:
-        print(f"[green]:white_check_mark: No duplicates among detector streams[/green]")
+        print(f"[green]:white_check_mark : No duplicates among detector streams[/green]")
 
 
     gid_duplicates = find_duplicates([strm.geo_id for strm in streams])
@@ -594,11 +598,74 @@ def validate_detstreams(obj):
     if gid_duplicates:
         print(f"[yellow]WARNING: found duplicates in geo ids {strm_duplicates}[/yellow]")
     else:
-        print(f"[green]:white_check_mark: No duplicates among geo ids[/green]")
+        print(f"[green]:white_check_mark : No duplicates among geo ids[/green]")
 
 
 
-    # start_ipython(locals())
+@cli.command(short_help="Validate smart applications in database")
+@click.pass_obj
+def validate_smart_apps(obj):
+    """
+    Performs basic validation on smart daq applications a database.
+
+    Implemented tests:
+    - `services`: The exposed service consistency between application interface and network rules is checked.
+      the services referenced in network rules are compared with the list in the `exposes_service` attribute.
+      The tedt fails if any of the network rules services is not present in `exposes_service`.
+    """
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class TestReport:
+        passed: bool
+        details : list
+
+    from rich.highlighter import ReprHighlighter
+    rh = ReprHighlighter()
+    cfg = obj.cfg
+
+    sapps = cfg.get_dals('SmartDaqApplication')
+
+    reports = {}
+    for sa in sapps:
+        print(f"Validating '{sa.id}'")
+        test_reports = {}
+
+        missing_services = []
+        for r in sa.network_rules:
+            if r.descriptor.associated_service not in sa.exposes_service:
+                missing_services.append(r.descriptor.associated_service)
+
+        test_reports['services'] = TestReport(not bool(missing_services), missing_services)
+        
+        reports[sa.id] = test_reports
+        
+
+
+    # Prepare report table
+    rep_cols = set()
+    for rep in reports.values():
+        rep_cols.update(rep.keys())
+
+    
+    t = Table(title="SmartDaqApp Validation Report")
+    t.add_column("app name")
+    for c in rep_cols:
+        t.add_column(c)
+
+    for name, rep in reports.items():
+        row = [name]
+        for c in rep_cols:
+            # TODO: specific to the services case
+            icon  = ':white_check_mark:' if rep[c].passed else ':x:'
+            details = str([i.id for i in rep[c].details])
+            row.append( f"{icon} {details}")
+
+
+        t.add_row(*row)
+
+    print(t)
 
 if __name__== "__main__":
     cli(obj=DaqInspectorContext())

--- a/scripts/daqconf_inspector.py
+++ b/scripts/daqconf_inspector.py
@@ -479,7 +479,7 @@ def show_object_tree(obj, uid, show_attrs, path, level):
 #     IPython.embed(colors="neutral")
 
 
-@cli.command(short_help="Validate detector strams in the database")
+@cli.command(short_help="Validate detector streams in the database")
 @click.pass_obj
 def validate_detstreams(obj):
     """

--- a/scripts/daqconf_inspector.py
+++ b/scripts/daqconf_inspector.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+from rich import print
+from rich.tree import Tree
+
+import click
+
+import conffwk
+
+import IPython
+
+class DaqInspectorContext:
+    pass
+
+
+def segment_tree(cfg, segment, show_path = False):
+
+    path = f"[blue]{cfg.get_obj(segment.className(), segment.id).contained_in()}[/blue]" if show_path else ""
+    tree = Tree(f"[yellow]{segment.id}[/yellow] {path}")
+    c = segment.controller
+    path = f"[blue]{cfg.get_obj(c.className(), c.id).contained_in()}[/blue]" if show_path else ""
+    ports = ', '.join([f'{svc.port}({svc.protocol})' for svc in c.exposes_service ])
+    host = f"[medium_purple1]{c.runs_on.runs_on.id}[/medium_purple1]"
+    tree.add(f"[cyan]controller[/cyan]: [green]{c.id}[/green][magenta]@{c.className()}[/magenta] on {host} [{ports}] {path}")
+    if segment.applications:
+        app_tree = tree.add(f"[cyan]applicationss[/cyan]")
+        for a in segment.applications:
+            if a is None:
+                print(f"Detected None application in {segment.id}")
+                continue
+            path = f"[blue]{cfg.get_obj(a.className(), a.id).contained_in()}[/blue]" if show_path else ""
+            ports = ', '.join([f'{svc.port}({svc.protocol})' for svc in c.exposes_service ])
+            host = f"[medium_purple1]{a.runs_on.runs_on.id}[/medium_purple1]"
+            app_tree.add(f"[green]{a.id}[/green][magenta]@{a.className()}[/magenta] on {host} [{ports}] {path}")
+    if segment.segments:
+        seg_tree = tree.add(f"[cyan]segments[/cyan]")
+        for s in segment.segments:
+            if s is None:
+                print(f"Detected None segment in {segment.id}")
+                continue
+            seg_tree.add(segment_tree(cfg, s, show_path))
+
+    return tree
+    
+
+
+@click.group()
+@click.option('-i', '--interactive', is_flag=True, show_default=True, default=False)
+@click.argument('config_file')
+@click.pass_obj
+def cli(obj, interactive, config_file):
+    cfg = conffwk.Configuration(f"oksconflibs:{config_file}")
+    obj.cfg = cfg
+
+    if interactive:
+        IPython.embed(colors="neutral")
+
+
+@cli.command()
+@click.option('-p', '--show-paths', is_flag=True, show_default=True, default=False)
+@click.pass_obj
+def show_sessions(obj, show_paths):
+    """
+    """
+    
+    cfg = obj.cfg
+
+    print("Sessions")
+    sessions = cfg.get_objs("Session")
+    for s in sessions:
+        print(f" - '{s.UID()}' [blue]{s.contained_in()}[/blue]")
+
+    print()
+
+    for so in sessions:
+        s = cfg.get_dal('Session', so.UID())
+        tree = Tree(f"Session [yellow]{s.id}[/yellow]")
+
+        tree.add(segment_tree(cfg, s.segment, show_paths))
+        print(tree)
+    print()
+
+@cli.command()
+@click.argument('klass')
+@click.pass_obj
+def show_class(obj, klass):
+
+    cfg = obj.cfg
+    
+    if klass not in cfg.classes():
+        print('f[red]Class {klass} unknow to configuration[/red]')
+        print(f'Known classes: {cfg.classes()}')
+        raise SystemExit(-1)
+    print(f"Showing objects belonging to {klass}")
+
+    attrs = cfg.attributes(klass)
+    rels = cfg.relations(klass)
+
+
+    for a in attrs:
+        print(a)
+
+
+
+    IPython.embed(colors="neutral")
+
+
+
+@cli.command()
+@click.pass_obj
+def check_detstreams(obj):
+
+    cfg = obj.cfg
+    print("DetectorStreams")
+
+    IPython.embed(colors="neutral")
+
+if __name__== "__main__":
+    cli(obj=DaqInspectorContext())

--- a/scripts/daqconf_inspector.py
+++ b/scripts/daqconf_inspector.py
@@ -19,6 +19,7 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
     Create segment branch of the configuration tree
     '''
 
+
     def enabled_to_emoji(enabled: Union[int, None]) -> str:
         match enabled:
             case 1:
@@ -28,9 +29,12 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
             case -1:
                 return ':x:' 
             case _:
-                return ''
+                return ':blue_circle:'
             
     def get_enabled(cfg, session, obj):
+        if not obj.isDalType('Component'):
+            return None
+
         enabled = not confmodel.component_disabled(cfg._obj, session.id, obj.id)
         if enabled:
             return enabled
@@ -38,9 +42,6 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
         enabled -= (obj in session.disabled)
         return enabled
         
-
-
-
 
     path = f"[blue]{cfg.get_obj(segment.className(), segment.id).contained_in()}[/blue]" if show_path else ""
     enabled = get_enabled(cfg, session, segment) if session else None
@@ -95,6 +96,7 @@ def cli(obj, interactive, config_file):
 @click.pass_obj
 def show_sessions(obj, show_paths):
     """
+    Display the list of sessions available in the configuration database and their internal structure
     """
     
     cfg = obj.cfg
@@ -114,12 +116,31 @@ def show_sessions(obj, show_paths):
         print(tree)
     print()
 
+
+@cli.command()
+@click.pass_obj
+def list_classes(obj):
+    """Prints the list of classes known to configuration"""
+    from rich.highlighter import ReprHighlighter
+
+    rh = ReprHighlighter()
+    cfg = obj.cfg
+
+    table = Table("Classes")
+    table.add_column('Class', 'Objects')
+    for k in sorted(cfg.classes()):
+        table.add_row(k, rh(str([o.UID() for o in cfg.get_objs(k)])))
+    print(table)
+
 @cli.command()
 @click.argument('klass')
 @click.option('-v/-h','--vertical/--horizontal', "vtable", default=True)
 @click.pass_obj
 def show_class(obj, klass,vtable):
+    from rich.highlighter import ReprHighlighter
 
+    rh = ReprHighlighter()
+ 
     cfg = obj.cfg
     
     if klass not in cfg.classes():
@@ -140,16 +161,16 @@ def show_class(obj, klass,vtable):
             table.add_column(do.id)
 
         for a in attrs:
-            table.add_row(*([a]+[str(getattr(do,a)) for do in dals]))
+            table.add_row(*([a]+[rh(str(getattr(do,a))) for do in dals]))
 
         for r in rels:
             rel_vals = [getattr(do,r) for do in dals]
             rel_strs = []
             for rv in rel_vals:
                 if isinstance(rv,list):
-                    rel_strs += [','.join([getattr(v,'id', 'None') for v in rv])]
+                    rel_strs += [rh(str([getattr(v,'id', 'None') for v in rv]))]
                 else:
-                    rel_strs += [getattr(rv,'id', 'None')]
+                    rel_strs += [rh(getattr(rv,'id', 'None'))]
             table.add_row(*([f"{r} ([yellow]{rels[r]['type']}[/yellow])"]+rel_strs))
     else:
 
@@ -162,14 +183,14 @@ def show_class(obj, klass,vtable):
             table.add_column(f"{r} ([yellow]{rels[r]['type']}[/yellow])")
         
         for do in dals:
-            attr_vals = [str(getattr(do,a)) for a in attrs]
+            attr_vals = [rh(str(getattr(do,a))) for a in attrs]
             rel_vals = [getattr(do,r) for r in rels]
             rel_strs = []
             for rv in rel_vals:
                 if isinstance(rv,list):
-                    rel_strs += [','.join([getattr(v,'id', 'None') for v in rv])]
+                    rel_strs += [rh(str([getattr(v,'id', 'None') for v in rv]))]
                 else:
-                    rel_strs += [getattr(rv,'id', 'None')]
+                    rel_strs += [rh(getattr(rv,'id', 'None'))]
             table.add_row(*([do.id]+attr_vals+rel_strs))
 
     print(table)
@@ -179,7 +200,8 @@ def show_class(obj, klass,vtable):
 @click.argument('id')
 @click.pass_obj
 def show_object_tree(obj, klass, id):
-
+    from rich.highlighter import ReprHighlighter
+    rh = ReprHighlighter()
     cfg = obj.cfg
 
     if klass not in cfg.classes():
@@ -187,29 +209,13 @@ def show_object_tree(obj, klass, id):
         print(f'Known classes: {sorted(cfg.classes())}')
         raise SystemExit(-1)
 
-    do = cfg.get_dal(klass, id)
-
-    def make_obj_tree(dal_obj):
-        tree = Tree(f"[green]{dal_obj.id}[/green][magenta]@{dal_obj.className()}[/magenta]")
-        attr_tree = tree.add('[yellow]attributes[/yellow]')
-        attrs = cfg.attributes(dal_obj.className(), True)
-        for a in attrs:
-            attr_tree.add(f"[cyan]{a}[/cyan] = {getattr(dal_obj, a)}")
-        
-        rel_tree = tree.add('[yellow]relationships[/yellow]')
-        rels = cfg.relations(dal_obj.className(), True)
-        for rel, rinfo in rels.items():
-            rel_val = getattr(dal_obj, rel)
-            r_tree = rel_tree.add(f"[cyan]{rel}[/cyan]@[magenta]{rinfo['type']}[/magenta] {('['+str(len(rel_val))+']' if isinstance(rel_val, list) else '')}")
-            if not isinstance(rel_val,list):
-                rel_val = [rel_val]
-            for v in rel_val:
-                if v is None:
-                    continue
-                r_tree.add(make_obj_tree(v))
-        return tree
     
+    tokens = id.split('.')
+    parent = tokens[0]
+    children = tokens[1:]
 
+    do = cfg.get_dal(klass, id)
+    
     def make_obj_tree(dal_obj):
         tree = Tree(f"[green]{dal_obj.id}[/green][magenta]@{dal_obj.className()}[/magenta]")
         # attr_tree = tree.add('[yellow]attributes[/yellow]')
@@ -231,13 +237,8 @@ def show_object_tree(obj, klass, id):
         return tree
 
 
-    tree = make_obj_tree(do)
+    tree = make_obj_tree(do, children)
     print(tree)
-
-
-    if False:
-        import IPython
-        IPython.embed(colors='neutral')
 
 
 @cli.command()

--- a/scripts/daqconf_inspector.py
+++ b/scripts/daqconf_inspector.py
@@ -7,49 +7,133 @@ from rich.table import Table
 import click
 
 import conffwk
-import confmodel
 
 import IPython
 
-class DaqInspectorContext:
-    pass
+
+def is_enabled(cfg, session, obj):
+    import confmodel
+
+    """Helper function that returns the status of an object in a session"""
+    if not obj.isDalType('Component'):
+        return None
+
+    enabled = not confmodel.component_disabled(cfg._obj, session.id, obj.id)
+    if enabled:
+        return enabled
+    
+    enabled -= (obj in session.disabled)
+    return enabled
+
+def get_attribute_info(o):
+    return o.__schema__['attribute']
+
+def get_relation_info(o):
+    return o.__schema__['relation']
+
+def get_attribute_list(o):
+    return list(get_attribute_info(o))
+
+def get_relation_list(o):
+    return list(get_relation_info(o))
+
+def get_superclass_list(o):
+    return o.__schema__['superclass']
+
+def get_subclass_list(o):
+    return o.__schema__['subclass']
+
+def compare_dal_obj(a, b):
+    """Compare two dal objects by content"""
+
+    # TODO: add a check on a and b being dal objects
+    # There is no base class for dal objects in python, but dal objects have _shcema__objects.
+
+    if a.className() != b.className():
+        return False
+
+    attrs = get_attribute_list(a)
+    rels = get_relation_list(a)
+
+    a_attrs = {x:getattr(a, x) for x in attrs}
+    b_attrs = {x:getattr(b, x) for x in attrs}
+
+    a_rels = {x:getattr(a, x) for x in rels}
+    b_rels = {x:getattr(b, x) for x in rels}
+
+
+    return (a_attrs == b_attrs) and (a_rels == b_rels)
+
+
+#---------------
+def find_related_dals(dal_obj, dal_group: set):
+
+
+    rels = get_relation_list(dal_obj)
+
+    rel_objs = set()
+    for rel in rels:
+        rel_val = getattr(dal_obj, rel)
+
+        if rel_val is None:
+            continue
+
+        rel_objs.update(rel_val if isinstance(rel_val,list) else [rel_val])
+
+    # Isolate relationship objects that are not in the dal_group yet
+    new_rel_objs = rel_objs - dal_group
+
+    # Safely add the new object to the group
+    dal_group.update(rel_objs)
+    for o in new_rel_objs:
+        if o is None:
+            continue
+
+        find_related_dals(o, dal_group)
+        
+from collections.abc import Iterable
+def find_duplicates( collection: Iterable ):
+    """
+    Find duplicated dal objects in a collection by based on objects attributes and relationships
+    """
+    
+    n_items = len(collection)
+    duplicates = set()
+    for i in range(n_items):
+        for j in range(i+1, n_items):
+            if compare_dal_obj(collection[i], collection[j]):
+                print(f"{i} {j} AAAAARGH")
+                duplicates.add(collection[i])
+                duplicates.add(collection[j])
+
+    return duplicates
+
+def enabled_to_emoji(enabled: Union[int, None]) -> str:
+    """
+    Convert enabled values [enabled, disabled, disabled-by-logic] into standard emojis
+    """
+    match enabled:
+        case 1:
+            return ':white_check_mark:'
+        case 0:
+            return ':heavy_large_circle:' 
+        case -1:
+            return ':x:' 
+        case _:
+            return ':blue_circle:'
 
 def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> Tree:
     '''
-    Create segment branch of the configuration tree
-    '''
-
-
-    def enabled_to_emoji(enabled: Union[int, None]) -> str:
-        match enabled:
-            case 1:
-                return ':white_check_mark:'
-            case 0:
-                return ':heavy_large_circle:' 
-            case -1:
-                return ':x:' 
-            case _:
-                return ':blue_circle:'
-            
-    def get_enabled(cfg, session, obj):
-        if not obj.isDalType('Component'):
-            return None
-
-        enabled = not confmodel.component_disabled(cfg._obj, session.id, obj.id)
-        if enabled:
-            return enabled
-        
-        enabled -= (obj in session.disabled)
-        return enabled
-        
+    Create a segment branch of the session tree as a rich.Tree object
+    ''' 
 
     path = f"[blue]{cfg.get_obj(segment.className(), segment.id).contained_in()}[/blue]" if show_path else ""
-    enabled = get_enabled(cfg, session, segment) if session else None
+    enabled = is_enabled(cfg, session, segment) if session else None
     tree = Tree(f"{enabled_to_emoji(enabled)} [yellow]{segment.id}[/yellow] {path}")
 
     c = segment.controller
     path = f"[blue]{cfg.get_obj(c.className(), c.id).contained_in()}[/blue]" if show_path else ""
-    ports = ', '.join([f'{svc.port}({svc.protocol})' for svc in c.exposes_service ])
+    ports = ', '.join([f'{svc.port}([orange1]{svc.protocol}[/orange1])' for svc in c.exposes_service ])
     host = f"[medium_purple1]{c.runs_on.runs_on.id}[/medium_purple1]"
     tree.add(f"[cyan]controller[/cyan]: [green]{c.id}[/green][magenta]@{c.className()}[/magenta] on {host} [{ports}] {path}")
 
@@ -61,9 +145,9 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
                 continue
 
             path = f"[blue]{cfg.get_obj(a.className(), a.id).contained_in()}[/blue]" if show_path else ""
-            ports = ', '.join([f'{svc.port}({svc.protocol})' for svc in c.exposes_service ])
+            ports = ', '.join([f'{svc.port}([orange1]{svc.protocol}[/orange1])' for svc in c.exposes_service ])
             host = f"[medium_purple1]{a.runs_on.runs_on.id}[/medium_purple1]"
-            enabled = get_enabled(cfg, session, a) if session else None
+            enabled = is_enabled(cfg, session, a) if session else None
 
             app_tree.add(f"{enabled_to_emoji(enabled)} [green]{a.id}[/green][magenta]@{a.className()}[/magenta] on {host} [{ports}] {path}")
 
@@ -76,14 +160,34 @@ def make_segment_tree(cfg, segment, session: None, show_path: bool = False) -> T
             seg_tree.add(make_segment_tree(cfg, s, session, show_path))
 
     return tree
-    
 
 
-@click.group()
-@click.option('-i', '--interactive', is_flag=True, show_default=True, default=False)
+def validate_oks_uid(ctx, param, value):
+    """
+    Helper function to validate OKS UID options or arguments accorinf to the format id@class
+    """
+    if isinstance(value, tuple):
+        return value
+
+    try:
+        id, _, klass = value.partition("@")
+        return str(id), str(klass)
+    except ValueError:
+        raise click.BadParameter("format must be '<id>@<class>'")
+
+class DaqInspectorContext:
+    pass
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.option('-i', '--interactive', is_flag=True, show_default=True, default=False, help="Start an interactive IPython session after executing the commands")
 @click.argument('config_file')
 @click.pass_obj
 def cli(obj, interactive, config_file):
+    """
+    A collection of helper commands to inspect dunedaq OKS databases and objects
+    """
     cfg = conffwk.Configuration(f"oksconflibs:{config_file}")
     obj.cfg = cfg
 
@@ -91,13 +195,15 @@ def cli(obj, interactive, config_file):
         IPython.embed(colors="neutral")
 
 
-@cli.command()
-@click.option('-p', '--show-paths', is_flag=True, show_default=True, default=False)
+@cli.command(short_help="Show sessions information")
+@click.option('-p', '--show-file_paths', is_flag=True, show_default=True, default=False)
 @click.pass_obj
-def show_sessions(obj, show_paths):
+def show_sessions(obj, show_file_paths):
     """
-    Display the list of sessions available in the configuration database and their internal structure
+    Show high level information about the sessions from the configuration database
     """
+    from rich.highlighter import ReprHighlighter
+    rh = ReprHighlighter()
     
     cfg = obj.cfg
 
@@ -109,18 +215,81 @@ def show_sessions(obj, show_paths):
     print()
 
     for so in sessions:
+
+        grid = Table.grid("")
+        
+
         s = cfg.get_dal('Session', so.UID())
-        tree = Tree(f"Session [yellow]{s.id}[/yellow]")
+        tree = Tree(f"[yellow]{s.id}[/yellow]")
+        infra_tree = tree.add('[yellow]infra-apps[/yellow]')
+        for a in s.infrastructure_applications:
+            infra_tree.add(a.id)
 
-        tree.add(make_segment_tree(cfg, s.segment, s, show_paths))
-        print(tree)
-    print()
+        tree.add(make_segment_tree(cfg, s.segment, s, show_file_paths))
+
+        t = Table("body", title='Session Tree', show_header=False, expand=True)
+        t.add_row(tree)
+        grid.add_row(t)
+        
+        # print(t)
+        
+        session_objs = set()
+        find_related_dals(s, session_objs)
+
+        # Find all objects in the top segment (exclude disabled, variables and infra in the resource count))
+        segment_objs = set()
+        find_related_dals(s.segment, segment_objs)        
+        res = [o for o in segment_objs if 'ResourceBase' in o.oksTypes()]
 
 
-@cli.command()
+
+        t = Table(title=s.id, show_header=False, expand=True)
+        t.add_column('name')
+        t.add_column('value')
+
+        t.add_row('Objects', rh(str(len(session_objs))))
+        t.add_row('Disabled mask', rh(str([ i.id for i in s.disabled])))
+        t.add_row('Disabled resources', rh(str([ r.id for r in res if is_enabled(cfg, s, r) != 1])))
+        # print(t)
+        grid.add_row(t)
+
+        disabled_not_in_session = set(s.disabled)-segment_objs
+        if disabled_not_in_session:
+            print(f"⚠️ {sorted(disabled_not_in_session)}")
+
+        if s.environment:
+            # print(s.environment)
+            env_objs = set()
+            for e in s.environment:
+                env_objs.add(e)
+                find_related_dals(e, env_objs)
+            # print(env_objs)
+            # continue
+
+            env_var = sorted(env_objs, key=lambda x: x.id)
+
+            t = Table(title="Environment", show_header=False,  expand=True)
+            t.add_column('name')
+            t.add_column('value')
+            for e in env_var:
+                if 'Variable' not in e.oksTypes():
+                    continue
+                t.add_row(e.id, e.value)
+            # print(t)
+            grid.add_row(t)
+            print(grid)
+            print()
+
+    # IPython.embed(colors="neutral")
+
+@cli.command(short_help="List known classes and objects for each class")
 @click.pass_obj
-def list_classes(obj):
-    """Prints the list of classes known to configuration"""
+@click.option('-d', "--show-derived-objects-as-parents", "show_derived", is_flag=True, default=False, help="Include derived objects in parent class listing")
+def list_classes(obj, show_derived):
+    """
+    Prints on screen the list of classes known to the schema,
+    together with the ids of objects belonging to that class.
+    """
     from rich.highlighter import ReprHighlighter
 
     rh = ReprHighlighter()
@@ -129,14 +298,18 @@ def list_classes(obj):
     table = Table("Classes")
     table.add_column('Class', 'Objects')
     for k in sorted(cfg.classes()):
-        table.add_row(k, rh(str([o.UID() for o in cfg.get_objs(k)])))
+        table.add_row(k, rh(str([o.UID() for o in cfg.get_objs(k) if (o.class_name() == k or show_derived)])))
     print(table)
 
-@cli.command()
+@cli.command(short_help="Show properties of objects forma class")
 @click.argument('klass')
-@click.option('-v/-h','--vertical/--horizontal', "vtable", default=True)
+@click.option('-v/-h','--vertical/--horizontal', "vtable", default=True, help="Vertical or horizontal orientation")
 @click.pass_obj
-def show_class(obj, klass,vtable):
+def show_obj_of_class(obj, klass, vtable):
+    """
+    Show attributes and relationships of all objects in the database belonging to KLASS
+    """
+
     from rich.highlighter import ReprHighlighter
 
     rh = ReprHighlighter()
@@ -195,11 +368,16 @@ def show_class(obj, klass,vtable):
 
     print(table)
 
-@cli.command()
+@cli.command(short_help="Show relationship tree")
 @click.argument('klass')
 @click.argument('id')
+@click.option('+a/-a','--show-attributes/--hide-attributes', "show_attrs", default=True, help="Show/Hide attributes")
+@click.option('-l','--level', "level", default=True, help="Recursion level in the object tree")
 @click.pass_obj
-def show_object_tree(obj, klass, id):
+def show_relation_tree(obj, klass, id, show_attrs):
+    """
+    Show the relationship tree of the OKS object with ID@KLASS identifier.
+    """
     from rich.highlighter import ReprHighlighter
     rh = ReprHighlighter()
     cfg = obj.cfg
@@ -210,43 +388,158 @@ def show_object_tree(obj, klass, id):
         raise SystemExit(-1)
 
     
-    tokens = id.split('.')
-    parent = tokens[0]
-    children = tokens[1:]
+    path = id.split('.')
+    parent = path[0]
 
-    do = cfg.get_dal(klass, id)
-    
-    def make_obj_tree(dal_obj):
+    try:
+        do = cfg.get_dal(klass, parent)
+    except RuntimeError as e:
+        raise click.BadArgumentUsage(f"Object '{id}' does not exist")
+
+
+
+    def make_obj_tree(dal_obj, show_attrs, path=[]):
+
         tree = Tree(f"[green]{dal_obj.id}[/green][magenta]@{dal_obj.className()}[/magenta]")
-        # attr_tree = tree.add('[yellow]attributes[/yellow]')
+
         attrs = cfg.attributes(dal_obj.className(), True)
-        for a in attrs:
-            tree.add(f"[cyan]{a}[/cyan] = {getattr(dal_obj, a)}")
-        
-        # rel_tree = tree.add('[yellow]relationships[/yellow]')
+        rels = cfg.relations(dal_obj.className(), True)
+
+        rel_sel = None
+        if path:
+            if path[0] not in rels:
+                raise click.BadArgumentUsage(f"Object '{path[0]}' does not exist in {dal_obj.id}")
+            else:
+                rel_sel = path[0]
+                path = path[1:]
+
+        if show_attrs:
+            for a in attrs:
+                tree.add(f"[cyan]{a}[/cyan] = {getattr(dal_obj, a)}")
+            
         rels = cfg.relations(dal_obj.className(), True)
         for rel, rinfo in rels.items():
+            # Filter on relationship name if path is specified
+            if rel_sel and rel != rel_sel:
+                continue
+
             rel_val = getattr(dal_obj, rel)
             r_tree = tree.add(f"[yellow]{rel}[/yellow]@[magenta]{rinfo['type']}[/magenta] {('['+str(len(rel_val))+']' if isinstance(rel_val, list) else '')}")
+
             if not isinstance(rel_val,list):
                 rel_val = [rel_val]
-            for v in rel_val:
-                if v is None:
+
+            for val in rel_val:
+                if path and val.id != path[0]:
                     continue
-                r_tree.add(make_obj_tree(v))
+                if val is None:
+                    continue
+                r_tree.add(make_obj_tree(val, show_attrs, path[1:]))
         return tree
 
 
-    tree = make_obj_tree(do, children)
+    tree = make_obj_tree(do, show_attrs, path[1:])
     print(tree)
+
+        
+@cli.command()
+@click.argument('uid', type=click.UNPROCESSED, callback=validate_oks_uid, default=None)
+@click.pass_obj
+def test_find_relations(obj, uid):
+
+    cfg = obj.cfg
+    id, klass = uid
+
+
+    if klass not in cfg.classes():
+        print(f'[red]Class {klass} unknow to configuration[/red]')
+        print(f'Known classes: {sorted(cfg.classes())}')
+        raise SystemExit(-1)
+
+    try:
+        dal_obj = cfg.get_dal(klass, id)
+    except RuntimeError as e:
+        raise click.BadArgumentUsage(f"Object '{id}' does not exist")
+    
+    print(dal_obj)
+    
+    grp = set()
+    find_related_dals(dal_obj, grp)
+
+    print(f"Found {len(grp)} objects related to {id}@{klass}")
+    # print(grp)
+    IPython.embed(colors="neutral")
 
 
 @cli.command()
 @click.pass_obj
 def check_detstreams(obj):
 
+    from rich.highlighter import ReprHighlighter
+    rh = ReprHighlighter()
     cfg = obj.cfg
-    print("DetectorStreams")
+
+
+    klass = 'DetectorStream'
+    ds_attrs = cfg.attributes(klass, True)
+    ds_rels = cfg.relations(klass, True)
+
+    if list(ds_rels) != ['geo_id']:
+        raise click.ClickException(f"Unexpected relationships found in DetectorStream {ds_rels}")
+
+
+    gid_attrs = cfg.attributes("GeoId", True)
+    gid_rels = cfg.relations("GeoId", True)
+
+    if gid_rels:
+        raise click.ClickException("Geoids are not expected to have relationships")
+
+
+    streams = cfg.get_dals(klass)
+    streams = sorted(streams, key=lambda x: x.source_id)
+
+
+    table = Table(title='DetectorStreams')
+    table.add_column('id')
+    table.add_column('status')
+
+    for a in ds_attrs:
+        table.add_column(a)
+
+    table.add_column('geo_id.id')
+
+    for a in gid_attrs:
+        table.add_column(f"geoid.{a}")
+
+
+    for strm in streams:
+        enabled_marker = ':blue_circle:'
+        
+        ds_attr_vals = [rh(str(getattr(strm,a))) for a in ds_attrs]
+        gid_attr_vals = [rh(str(getattr(strm.geo_id,a))) for a in gid_attrs]
+
+        table.add_row(*([strm.id, enabled_marker]+ds_attr_vals+[strm.geo_id.id]+gid_attr_vals))
+
+    print(table)
+
+    # Check for duplicate strm
+    strm_duplicates = find_duplicates(streams)
+
+    if strm_duplicates:
+        print(f"[yellow]WARNING: found duplicates in detector streams {strm_duplicates}[/yellow]")
+    else:
+        print(f"[green]:white_check_mark: No duplicates among detector streams[/green]")
+
+
+    gid_duplicates = find_duplicates([strm.geo_id for strm in streams])
+
+    if gid_duplicates:
+        print(f"[yellow]WARNING: found duplicates in geo ids {strm_duplicates}[/yellow]")
+    else:
+        print(f"[green]:white_check_mark: No duplicates among geo ids[/green]")
+
+
+
 
     IPython.embed(colors="neutral")
 

--- a/scripts/daqconf_inspector.py
+++ b/scripts/daqconf_inspector.py
@@ -116,8 +116,9 @@ def show_sessions(obj, show_paths):
 
 @cli.command()
 @click.argument('klass')
+@click.option('-v/-h','--vertical/--horizontal', "vtable", default=True)
 @click.pass_obj
-def show_class(obj, klass):
+def show_class(obj, klass,vtable):
 
     cfg = obj.cfg
     
@@ -131,46 +132,45 @@ def show_class(obj, klass):
 
     dals = cfg.get_dals(klass)
 
-    table = Table(title=klass)
-    table.add_column('id', style="cyan")
-    for a in attrs:
-        table.add_column(a)
+    if vtable:
+        table = Table(title=klass)
+        table.add_column('Member', style="cyan")
 
-    for r,ri in rels.items():
-        table.add_column(f"{r} ([yellow]{rels[r]['type']}[/yellow])")
-    
-    for do in dals:
-        attr_vals = [str(getattr(do,a)) for a in attrs]
-        rel_vals = [getattr(do,r) for r in rels]
-        rel_strs = []
-        for rv in rel_vals:
-            if isinstance(rv,list):
-                rel_strs += [','.join([getattr(v,'id', 'None') for v in rv])]
-            else:
-                rel_strs += [getattr(rv,'id', 'None')]
-        table.add_row(*([do.id]+attr_vals+rel_strs))
+        for do in dals:
+            table.add_column(do.id)
 
+        for a in attrs:
+            table.add_row(*([a]+[str(getattr(do,a)) for do in dals]))
 
-    print(table)
+        for r in rels:
+            rel_vals = [getattr(do,r) for do in dals]
+            rel_strs = []
+            for rv in rel_vals:
+                if isinstance(rv,list):
+                    rel_strs += [','.join([getattr(v,'id', 'None') for v in rv])]
+                else:
+                    rel_strs += [getattr(rv,'id', 'None')]
+            table.add_row(*([f"{r} ([yellow]{rels[r]['type']}[/yellow])"]+rel_strs))
+    else:
 
-    table = Table(title=klass)
-    table.add_column('Member', style="cyan")
+        table = Table(title=klass)
+        table.add_column('id', style="cyan")
+        for a in attrs:
+            table.add_column(a)
 
-    for do in dals:
-        table.add_column(do.id)
-
-    for a in attrs:
-        table.add_row(*([a]+[str(getattr(do,a)) for do in dals]))
-
-    for r in rels:
-        rel_vals = [getattr(do,r) for do in dals]
-        rel_strs = []
-        for rv in rel_vals:
-            if isinstance(rv,list):
-                rel_strs += [','.join([getattr(v,'id', 'None') for v in rv])]
-            else:
-                rel_strs += [getattr(rv,'id', 'None')]
-        table.add_row(*([f"{r} ([yellow]{rels[r]['type']}[/yellow])"]+rel_strs))
+        for r,ri in rels.items():
+            table.add_column(f"{r} ([yellow]{rels[r]['type']}[/yellow])")
+        
+        for do in dals:
+            attr_vals = [str(getattr(do,a)) for a in attrs]
+            rel_vals = [getattr(do,r) for r in rels]
+            rel_strs = []
+            for rv in rel_vals:
+                if isinstance(rv,list):
+                    rel_strs += [','.join([getattr(v,'id', 'None') for v in rv])]
+                else:
+                    rel_strs += [getattr(rv,'id', 'None')]
+            table.add_row(*([do.id]+attr_vals+rel_strs))
 
     print(table)
 
@@ -178,7 +178,7 @@ def show_class(obj, klass):
 @click.argument('klass')
 @click.argument('id')
 @click.pass_obj
-def show_object(obj, klass, id):
+def show_object_tree(obj, klass, id):
 
     cfg = obj.cfg
 

--- a/scripts/daqconf_inspector.py
+++ b/scripts/daqconf_inspector.py
@@ -14,7 +14,7 @@ def start_ipython(loc):
         import IPython
         IPython.embed(colors="neutral")
     except ImportError:
-        pass
+        print(f"[red]IPython not available[/red]")
 
 def is_enabled(cfg, session, obj):
     import confmodel


### PR DESCRIPTION
`daqconf_inspector` is an utility script to develop ways to meaningfully inspect and visualise DAQ configuration databases and to prototype validation algorithms. 
The set of commands is limited at the moment, but it is expected to grow.

```
Usage: daqconf_inspector [OPTIONS] CONFIG_FILE COMMAND [ARGS]...

  An utility script to develop ways to meaningfully inspect and  visualise DAQ
  configuration databases and to prototype validation algorithms.

Options:
  -i, --interactive  Start an interactive IPython session after executing the
                     commands
  -h, --help         Show this message and exit.

Commands:
  list-classes           List known classes and objects for each class
  show-object-tree       Show relationship tree
  show-objects-of-class  Show properties of objects belonging to a class
  show-sessions          Show sessions information
  validate-detstreams    Validate detector streams in the database
  validate-smart-apps    Validate smart applications in database
```