### PR TITLE
Added logic in generate.py to add the value of the TRACE_FILE env var…

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -1128,6 +1128,12 @@ def generate_session(
 
     opmon_svc = db.get_dal(class_name="OpMonURI", uid="local-opmon-uri")
 
+    trace_file_var = None
+    TRACE_FILE = os.getenv("TRACE_FILE")
+    if TRACE_FILE is not None:
+        trace_file_var = dal.Variable("session-env-trace-file", name="TRACE_FILE", value=TRACE_FILE)
+        db.update_dal(trace_file_var)
+
     infrastructure_applications = []
     if connectivity_service_is_infrastructure_app:
         conn_svc = db.get_dal(
@@ -1135,11 +1141,13 @@ def generate_session(
         )
         infrastructure_applications.append(conn_svc)
 
+    env_vars_for_local_running = db.get_dal(class_name="VariableSet", uid="local-variables").contains
+    if trace_file_var is not None:
+        env_vars_for_local_running.append(trace_file_var)
+
     sessiondal = dal.Session(
         session_name,
-        environment=db.get_dal(
-            class_name="VariableSet", uid="local-variables"
-        ).contains,
+        environment=env_vars_for_local_running,
         segment=seg,
         detector_configuration=detconf,
         infrastructure_applications=infrastructure_applications,


### PR DESCRIPTION
… to the OKS Session, if that env var is set in the user's shell environment.

This will allow us to have control (e.g. enable and view) TRACE debug messages in our integtests.  

My sense is that this will *not* affect interactive running.  I believe that for interactive running, one will still need to add the TRACE_FILE Variable to the OKS Session (soon to be OKS System) in order to enable TRACE debug messages within a given system configuration.

I tested this change by verifying that TRACE messages appeared in the TRACE memory buffer when the minimal_system_quick_test was run with the TRACE_FILE env var set in the Linux shell environment.