### PR TITLE
New inspector command to display detector to daq connections

### DIFF
--- a/python/daqconf/session.py
+++ b/python/daqconf/session.py
@@ -1,6 +1,9 @@
 import conffwk
 
 def get_segment_apps(segment):
+    """
+    Gather the list of applications in the segment and its sub-segments
+    """
     apps = []
 
     for ss in segment.segments:
@@ -15,7 +18,9 @@ def get_segment_apps(segment):
 
 
 def get_session_apps(confdb, session_name=""):
-    """Get the apps defined in the given session"""
+    """
+    Gather the apps defined used in a session.
+    """
     if session_name == "":
         session_dals = confdb.get_dals(class_name="Session")
         if len(session_dals) == 0:
@@ -35,6 +40,9 @@ def get_session_apps(confdb, session_name=""):
 
 
 def get_apps_in_any_session(confdb):
+    """
+    Gather the applications used in any session present in the database
+    """
 
     output = {}
     session_dals = confdb.get_dals(class_name="Session")

--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -569,6 +569,7 @@ def show_d2d_connections(obj):
         sndr_grp = send_grps[0]
         sndrs = [ r for r in sndr_grp.contains if 'DetDataSender' in r.oksTypes()]
         if len(sndr_grp.contains) != len(sndrs):
+            print(sndr_grp.contains)
             raise RuntimeError(f"Not all sender in {conn.id} are DetDataSenders")
         
         strm_id_list = []

--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -5,6 +5,7 @@ from rich.tree import Tree
 from rich.table import Table
 
 import click
+import itertools
 
 import conffwk
 from daqconf.session import get_segment_apps
@@ -20,6 +21,20 @@ def start_ipython(loc):
         IPython.embed(colors="neutral")
     except ImportError:
         print(f"[red]IPython not available[/red]")
+
+
+def to_int_ranges(int_list):
+    """
+    Group a list of integers into ranges
+    """
+    groups = (list(x) for _, x in
+          itertools.groupby(sorted(int_list), lambda x, c=itertools.count(): x - next(c)))
+    return [(e[0], e[-1]) for e in groups]
+
+def ranges_to_str( int_ranges ):
+    return ', '.join(
+        f'{r[0]}-{r[1]}' if r[0] != r[1] else f'{r[0]}' for r in int_ranges
+    )
 
 
 def enabled_to_emoji(enabled: Union[int, None]) -> str:
@@ -522,33 +537,69 @@ def show_object_tree(obj, uid, show_attrs, focus_path, level):
     print(tree)
 
         
-# @cli.command()
-# @click.argument('uid', type=click.UNPROCESSED, callback=verify_oks_uid, default=None)
-# @click.pass_obj
-# def test_find_relations(obj, uid):
-
-#     cfg = obj.cfg
-#     id, klass = uid
+@cli.command(short_help="Show detector-daq connections")
+@click.pass_obj
+def show_d2d_connections(obj):
 
 
-#     if klass not in cfg.classes():
-#         print(f'[red]Class {klass} unknow to configuration[/red]')
-#         print(f'Known classes: {sorted(cfg.classes())}')
-#         raise SystemExit(-1)
+    from rich.highlighter import ReprHighlighter
+    rh = ReprHighlighter()
+    cfg = obj.cfg
 
-#     try:
-#         dal_obj = cfg.get_dal(klass, id)
-#     except RuntimeError as e:
-#         raise click.BadArgumentUsage(f"Object '{id}' does not exist")
-    
-#     print(dal_obj)
-    
-#     grp = set()
-#     find_related_dals(dal_obj, grp)
 
-#     print(f"Found {len(grp)} objects related to {id}@{klass}")
-#     # print(grp)
-#     IPython.embed(colors="neutral")
+    d2d = cfg.get_dals('DetectorToDaqConnection')
+
+    t = Table("connection", "receiver", "type",  "# senders", "send types", "source ids", "det ids", "crate ids", "slot ids", "stream ids")
+    for conn in d2d:
+
+        if len(conn.contains) != 2:
+            raise RuntimeError(f"Too many objects found in {conn.id} : {len(conn.contains)}(expected 1 senger group and 1 receiver)")
+
+        recs = [ r for r in conn.contains if 'DetDataReceiver' in r.oksTypes()]
+        send_grps = [ r for r in conn.contains if 'ResourceSetAND' in r.oksTypes()]
+
+        if len(recs) != 1:
+            raise RuntimeError(f"Multiple receivers found in connection {conn.id}")
+
+        if len(send_grps) != 1:
+            raise RuntimeError(f"Multiple sender groups found in connection {conn.id}")
+        
+
+        rcvr = recs[0]
+        sndr_grp = send_grps[0]
+        sndrs = [ r for r in sndr_grp.contains if 'DetDataSender' in r.oksTypes()]
+        if len(sndr_grp.contains) != len(sndrs):
+            raise RuntimeError(f"Not all sender in {conn.id} are DetDataSenders")
+        
+        strm_id_list = []
+        det_ids = set()
+        crate_ids = set()
+        slot_ids = set()
+        stream_ids = set()
+        sndr_types = set()
+        for sndr in sndrs:
+            sndr_types.add(sndr.className())
+            for strm in sndr.contains:
+                strm_id_list.append(strm.source_id)
+                det_ids.add(strm.geo_id.detector_id)
+                crate_ids.add(strm.geo_id.crate_id)
+                slot_ids.add(strm.geo_id.slot_id)
+                stream_ids.add(strm.geo_id.stream_id)
+
+        t.add_row(
+            rh(conn.id), 
+            rh(rcvr.id), 
+            rh(f"'{rcvr.className()}'"),
+            rh(str(len(sndrs))), 
+            rh(str(', '.join([f"'{s}'" for s in sndr_types]))), 
+            rh(ranges_to_str(to_int_ranges(strm_id_list))), 
+            rh(ranges_to_str(to_int_ranges(det_ids))), 
+            rh(ranges_to_str(to_int_ranges(crate_ids))), 
+            rh(ranges_to_str(to_int_ranges(slot_ids))),
+            rh(ranges_to_str(to_int_ranges(stream_ids))),
+            )
+
+    print(t)
 
 
 @cli.command(short_help="Verify detector streams in the database")

--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -208,7 +208,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option('-i', '--interactive', is_flag=True, show_default=True, default=False, help="Start an interactive IPython session after executing the commands")
-@click.argument('config_file')
+@click.argument('config_file', type=click.Path(exists=True))
 @click.pass_obj
 def cli(obj, interactive, config_file):
     """


### PR DESCRIPTION

Shows the DetectorToDAQ connections in the database

The receiver id and summary sender informations for each connection are shown in a compact table.

Example:

```
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ connection          ┃ receiver                   ┃ type             ┃ # senders ┃ send types         ┃ source ids  ┃ det ids ┃ crate ids ┃ slot ids    ┃ stream ids ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ np04-pds-connection │ flx-if-np04-pds            │ 'FelixInterface' │ 5         │ 'FelixDataSender'  │ 4, 9, 11-13 │ 2       │ 2         │ 4, 9, 11-13 │ 0          │
│ apa4-connections    │ dpdk-np04srv031-receiver-3 │ 'DPDKReceiver'   │ 10        │ 'HermesDataSender' │ 400-439     │ 3       │ 4         │ 0-4         │ 0-3, 64-67 │
│ apa3-connections    │ dpdk-np04srv031-receiver-2 │ 'DPDKReceiver'   │ 10        │ 'HermesDataSender' │ 300-339     │ 3       │ 3         │ 0-4         │ 0-3, 64-67 │
│ apa2-connections    │ dpdk-np04srv031-receiver-1 │ 'DPDKReceiver'   │ 10        │ 'HermesDataSender' │ 200-239     │ 3       │ 2         │ 0-4         │ 0-3, 64-67 │
│ apa1-connections    │ dpdk-np04srv031-receiver-0 │ 'DPDKReceiver'   │ 10        │ 'HermesDataSender' │ 100-139     │ 3       │ 1         │ 0-4         │ 0-3, 64-67 │
└─────────────────────┴────────────────────────────┴──────────────────┴───────────┴────────────────────┴─────────────┴─────────┴───────────┴─────────────┴────────────┘
```