### PR TITLE
Added an action plan for the start transition in the tc-maker applica…

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -941,6 +941,9 @@ def generate_trigger(
         ta_subscriber = db.get_dal(class_name="DataReaderConf", uid="ta-subscriber-1")
         ta_handler = db.get_dal(class_name="DataHandlerConf", uid="def-ta-handler")
 
+        # Action Plans
+        tc_maker_start = db.get_dal(class_name="ActionPlan", uid="tc-maker-start")
+
         tcmaker = dal.TriggerApplication(
             "tc-maker-1",
             runs_on=host,
@@ -952,6 +955,7 @@ def generate_trigger(
             opmon_conf=opmon_conf,
             data_subscriber=ta_subscriber,
             trigger_inputs_handler=ta_handler,
+            action_plans=[tc_maker_start],
         )
         db.update_dal(tcmaker)
 


### PR DESCRIPTION
…tion to the generate.py script. This is to ensure that the TriggerDataHandlerModule is started before the DataSubscriberModule in that application. This is needed to avoid the situation in which the DSH starts sending TAs to the TDHM before the latter is ready to receive them. When it is  not ready to receive them, the queue between the two modules can fill up, and the DSH emits an error message, which we would like to avoid.

This PR should be tested and merged in conjunction with one in daqsystemtest ([PR 181](https://github.com/DUNE-DAQ/daqsystemtest/pull/181)).    That PR has additional details about the problem that is being addressed and the solution that these changes implement.  It also has sample instructions for testing these changes.