### PR TITLE
Re-worked the set_session_env_var script to handle the case in which …

### DIFF
--- a/python/daqconf/set_session_env_var.py
+++ b/python/daqconf/set_session_env_var.py
@@ -1,7 +1,7 @@
 import conffwk
 import confmodel
 
-def set_session_env_var(oksfile, env_var_name, env_var_value, session_name):
+def set_session_env_var(oksfile, session_name, requested_env_var_name, requested_env_var_value):
     """Script to set the value of an environment variable in the specified Session of the
     specified OKS database file"""
     db = conffwk.Configuration("oksconflibs:" + oksfile)
@@ -15,19 +15,43 @@ def set_session_env_var(oksfile, env_var_name, env_var_value, session_name):
             print(f"Error could not find Session {session_name} in file {oksfile}")
             return
 
-    dal_name = "session-env-" + env_var_name
-    dal_name = dal_name.lower()
-    dal_name = dal_name.replace("_", "-")
-
     schemafiles = [
         "schema/confmodel/dunedaq.schema.xml"
     ]
     dal = conffwk.dal.module("dal", schemafiles)
-    new_or_updated_env = dal.Variable(dal_name, name=env_var_name, value=env_var_value)
-    db.update_dal(new_or_updated_env)
 
-    if not new_or_updated_env in session.environment:
-        session.environment.append(new_or_updated_env)
+    # First, check if the requested env var is already defined for the specified OKS Session
+    existing_env_var = None
+    for entry in session.environment:
+        if isinstance(entry, dal.VariableSet):
+            for subentry in entry.contains:
+                if subentry.name == requested_env_var_name:
+                    existing_env_var = subentry
+                    existing_env_var.value = requested_env_var_value
+                    break
+        else:
+            if entry.name == requested_env_var_name:
+                existing_env_var = entry
+                existing_env_var.value = requested_env_var_value
+
+        if existing_env_var is not None:
+            break
+
+    # if we found an existing env var, update the DB with the new value
+    if existing_env_var is not None:
+        db.update_dal(existing_env_var)
+
+    # otherwise, create a new env var and assign it to the OKS Session
+    else:
+        new_env_var_dal_name = "temporary-env-var-" + requested_env_var_name
+        new_env_var_dal_name = new_env_var_dal_name.lower()
+        new_env_var_dal_name = new_env_var_dal_name.replace("_", "-")
+
+        new_env_var = dal.Variable(new_env_var_dal_name, name=requested_env_var_name, value=requested_env_var_value)
+        db.update_dal(new_env_var)
+
+        session.environment.append(new_env_var)
         db.update_dal(session)
 
+    # commit all changes
     db.commit()

--- a/scripts/daqconf_set_session_env_var
+++ b/scripts/daqconf_set_session_env_var
@@ -7,10 +7,10 @@ from daqconf.set_session_env_var import set_session_env_var
 @click.argument('oksfile')
 @click.argument('env_var_name', required=True, nargs=1)
 @click.argument('env_var_value', required=True, nargs=1)
-def daqconf_set_session_env_var(oksfile, env_var_name, env_var_value, oks_session_name):
+def daqconf_set_session_env_var(oksfile, oks_session_name, env_var_name, env_var_value):
   """Script to set the value of an environment variable in the specified Session of the
   specified OKS database file"""
-  set_session_env_var(oksfile, env_var_name, env_var_value, oks_session_name)
+  set_session_env_var(oksfile, oks_session_name, env_var_name, env_var_value)
 
 if __name__ == '__main__':
   daqconf_set_session_env_var()


### PR DESCRIPTION
…the requested env var already exists in the specified OKS Session.

Previously, the script would just blindly create a new OKS Variable and add it to the OKS Session, even if one already existed for the requested env var.  Obviously, this was not good.

In the changes included here, if a new OKS Variable needs to be created, it is given a name of the form "temporary-env-<requested_env_var_name>".  The "temporary" prefix is intended to convey that it was created by a script and should not be committed as an official change without additional consideration by a developer (and likely a renaming).