### PR TITLE
Modified the generate_readout function inside the generate.py file to…

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -648,7 +648,9 @@ def generate_readout(
             ru.tp_handler = tphandler
             tp_sources = []
             tpbaseid = (appnum * 3) + 100
-            for plane in range(3):
+            # 30-Apr-2025, KAB: added support for 1 "plane" of non-TPC TPs (e.g. PDS).
+            # That is compared with the usual 3 planes of TPs for TPC detectors.
+            for plane in range(1 if det_id not in [3, 10, 11] else 3):
                 s_id = tpbaseid + plane
                 tps_dal = dal.SourceIDConf(
                     f"tp-srcid-{s_id}", sid=s_id, subsystem="Trigger"


### PR DESCRIPTION
… only create one TP data source for non-TPC detectors.

This change came about as part of trying to restore the PDS data-type test in the readout_type_scan integtest in daqsystemtest and add PDS TPs to that integtest.

When I ran some tests before I made this change, three TP-related modules were created in each ReadoutApp, but from what I see in configurations at NP02, only one TP-related module should be created for PDS/DAPHNE TPs.  And, with this change, I see the correct behavior in the PDS_TPG part of readout_type_scan.

