### PR TITLE
Restored a change in generate.py that somehow was lost in a recent re…

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -648,7 +648,9 @@ def generate_readout(
             ru.tp_handler = tphandler
             tp_sources = []
             tpbaseid = (appnum * 3) + 100
-            for plane in range(3):
+            # 30-Apr-2025, KAB: added support for 1 "plane" of non-TPC TPs (e.g. PDS).
+            # That is compared with the usual 3 planes of TPs for TPC detectors.
+            for plane in range(1 if det_id not in [3, 10, 11] else 3):
                 s_id = tpbaseid + plane
                 tps_dal = dal.SourceIDConf(
                     f"tp-srcid-{s_id}", sid=s_id, subsystem="Trigger"


### PR DESCRIPTION
…vert or merge.

The first indication that something was wrong was in a failure in the overnight running of the readout_type_scan regression test.

It's not clear to me what caused the relevant section of code to go missing, but this PR brings it back on the develop branch.