### PR TITLE
Simplified genmodules signature

### DIFF
--- a/apps/GraphBuilder.cpp
+++ b/apps/GraphBuilder.cpp
@@ -417,7 +417,7 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
     if (daqapp) {
       auto local_session = const_cast<dunedaq::confmodel::Session*>( // NOLINT
         local_database->get<dunedaq::confmodel::Session>(m_session_name));
-      auto modules = daqapp->generate_modules(local_database, m_oksfilename, local_session);
+      auto modules = daqapp->generate_modules(local_session);
 
       std::vector<std::string> allowed_conns{};
 


### PR DESCRIPTION
This PR removes the `confdb` and `dbfile` arguments of the `SmartDaqApplication::generate_modules(...)`.
