### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqconf VERSION 8.3.0)
+project(daqconf VERSION 8.4.0)
 
 find_package(daq-cmake REQUIRED )
 

--- a/apps/GraphBuilder.cpp
+++ b/apps/GraphBuilder.cpp
@@ -417,7 +417,7 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
     if (daqapp) {
       auto local_session = const_cast<dunedaq::confmodel::Session*>( // NOLINT
         local_database->get<dunedaq::confmodel::Session>(m_session_name));
-      auto modules = daqapp->generate_modules(local_database, m_oksfilename, local_session);
+      auto modules = daqapp->generate_modules(local_session);
 
       std::vector<std::string> allowed_conns{};
 

--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -874,6 +874,38 @@ def show_smartapp_mods(obj, session_id, app_id, show_attrs, level, focus_path):
 
     # start_ipython(locals())
 
+@cli.command(short_help="Show the status of a resource and its contained ones")
+@click.argument('session_id')
+@click.argument('resource_id')
+@click.option('+a/-a','--show-attributes/--hide-attributes', "show_attrs", default=True, help="Show/Hide attributes")
+@click.option('-l','--level', "level", type=int, default=None, help="Recursion level in the object tree")
+@click.option('-f','--focus', "focus_path", default=None, help="Path within the object relationships to focus on")
+@click.pass_obj
+def show_resources(obj, session_id, resource_id, show_attrs, level, focus_path):
+    import re
+
+    from rich.highlighter import ReprHighlighter
+    rh = ReprHighlighter()
+    cfg = obj.cfg
+    drr = DalRichRenderer(cfg)
+
+    focus_path = focus_path.split('.') if focus_path is not None else []
+    re_index = re.compile('([\w-]*)(\[([\w-]*)\])?')
+    path = []
+    for p in focus_path:
+        m = re_index.match(p)
+        if m is None:
+            raise RuntimeError("Incorrect systax of path specifier p")
+        rel,_,name = m.groups()
+        path.append((rel, name))
+
+    s = cfg.get_dal('Session', session_id)
+
+    r = cfg.get_dal('ResourceBase', resource_id)
+
+    t = drr.make_obj_tree(r, show_attrs, path, level, s)
+    print(t)
+
 
 if __name__== "__main__":
     cli(obj=DaqInspectorContext())


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.