### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc3 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqconf VERSION 8.4.0)
+project(daqconf VERSION 8.4.1)
 
 find_package(daq-cmake REQUIRED )
 

--- a/python/daqconf/generate_hwmap.py
+++ b/python/daqconf/generate_hwmap.py
@@ -29,13 +29,28 @@ def generate_hwmap(oksfile, n_streams, n_apps = 1, det_id = 3, app_host = "local
         for stream_no in range(n_streams):
             print (f"Generating {stream_no=}")
 
-            geo_dal = dal.GeoId(
-                f"geioId-{source_id}",
-                detector_id=det_id,
-                crate_id=app+1,
-                slot_id=0,
-                stream_id=stream_no,
-            )
+            # 28-May-2025, KAB: hack(?) to get DAPHNE TPs to have unique channel numbers
+            # within a single ReadoutApp. This involves setting DAPHNE slot numbers to
+            # unique values. There is probably more work to be done to get the DAPHNE
+            # and WIBEth crate/slot/stream numbers that we use in fake-data-playback and
+            # integration tests to better match real electronics, but hopefully this is
+            # sufficient for now.
+            if det_id in [2, 8, 9]:
+                geo_dal = dal.GeoId(
+                    f"geioId-{source_id}",
+                    detector_id=det_id,
+                    crate_id=app+1,
+                    slot_id=stream_no,
+                    stream_id=1,
+                )
+            else:
+                geo_dal = dal.GeoId(
+                    f"geioId-{source_id}",
+                    detector_id=det_id,
+                    crate_id=app+1,
+                    slot_id=0,
+                    stream_id=stream_no,
+                )
             db.update_dal(geo_dal)
             stream = dal.DetectorStream(
                 f"stream-{source_id}",


### PR DESCRIPTION
This PR is part of an overall merging of the `patch/fddaq-v5.3.x` branches into `develop` in the wake of release candidate 3 for `fddaq-v5.3.2`; note that the actual source branch, `johnfreeman/merge_fddaq-v5.3.2-rc3-a9_into_develop`, is an intermediary here. A test release was built with the source branch (`NFDT_DEV_250617_A9`) and successful integration tests were run (https://github.com/DUNE-DAQ/daq-release/actions/runs/15717205217). 