### PR TITLE
Added an option to set_session_env_var.py to allow users to specify that existing env var values should not be over-written

### DIFF
--- a/python/daqconf/set_session_env_var.py
+++ b/python/daqconf/set_session_env_var.py
@@ -1,7 +1,7 @@
 import conffwk
 import confmodel
 
-def set_session_env_var(oksfile, session_name, requested_env_var_name, requested_env_var_value):
+def set_session_env_var(oksfile, session_name, requested_env_var_name, requested_env_var_value, overwrite=True):
     """Script to set the value of an environment variable in the specified Session of the
     specified OKS database file"""
     db = conffwk.Configuration("oksconflibs:" + oksfile)
@@ -37,13 +37,21 @@ def set_session_env_var(oksfile, session_name, requested_env_var_name, requested
         if existing_env_var is not None:
             break
 
+    # if we found an existing env var, and we have been told not to over-write it, exit now
+    if existing_env_var is not None and not overwrite:
+        return
+
     # if we found an existing env var, update the DB with the new value
     if existing_env_var is not None:
         db.update_dal(existing_env_var)
 
     # otherwise, create a new env var and assign it to the OKS Session
     else:
-        new_env_var_dal_name = "temporary-env-var-" + requested_env_var_name
+        # 03-Jul-2025, KAB: switched from using a "temporary" string in the dal_name
+        # to using the session name. This means that each Session will get its own
+        # instance of the DAL Variable, which seems safer than having the possibility
+        # of multiple Sessions sharing the same Variable.
+        new_env_var_dal_name = session_name + "-env-var-" + requested_env_var_name
         new_env_var_dal_name = new_env_var_dal_name.lower()
         new_env_var_dal_name = new_env_var_dal_name.replace("_", "-")
 

--- a/scripts/daqconf_set_session_env_var
+++ b/scripts/daqconf_set_session_env_var
@@ -7,10 +7,12 @@ from daqconf.set_session_env_var import set_session_env_var
 @click.argument('oksfile')
 @click.argument('env_var_name', required=True, nargs=1)
 @click.argument('env_var_value', required=True, nargs=1)
-def daqconf_set_session_env_var(oksfile, oks_session_name, env_var_name, env_var_value):
+@click.option('--no_overwrite', default=False, is_flag=True,
+              help='Disables the to over-writing of an existing value for the specified env var')
+def daqconf_set_session_env_var(oksfile, oks_session_name, env_var_name, env_var_value, no_overwrite):
   """Script to set the value of an environment variable in the specified Session of the
   specified OKS database file"""
-  set_session_env_var(oksfile, oks_session_name, env_var_name, env_var_value)
+  set_session_env_var(oksfile, oks_session_name, env_var_name, env_var_value, (not no_overwrite))
 
 if __name__ == '__main__':
   daqconf_set_session_env_var()


### PR DESCRIPTION
This change was needed to support a change in the `integrationtest` repo ([PR 112](https://github.com/DUNE-DAQ/integrationtest/pull/112)) in which I added the setting of the TRACE_FILE env var in integtest configurations that do not already have that env var set.  Please see the `integrationtest` PR for more details.

I also modified the DAL name of the temporary Variables that are created in the configuration to hold the TRACE_FILE env var values to include the OKS Session name.  

Previously, a constant string was used, and this meant that more than one Session could share the same value for the TRACE_FILE env var.  It seemed safer to have dedicate DAL Variables for each Session.