### PR TITLE
Kbiery/adding crt to generate readout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqconf VERSION 8.6.0)
+project(daqconf VERSION 8.6.1)
 
 find_package(daq-cmake REQUIRED )
 

--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -520,6 +520,20 @@ def generate_readout(
             det_q = db.get_dal(
                 class_name="QueueConnectionRule", uid="tde-raw-data-rule"
             )
+        elif det_id == 12:
+            linkhandler = db.get_dal(
+                class_name="DataHandlerConf", uid="def-crt-bern-link-handler"
+            )
+            det_q = db.get_dal(
+                class_name="QueueConnectionRule", uid="crt-bern-raw-data-rule"
+            )
+        elif det_id == 13:
+            linkhandler = db.get_dal(
+                class_name="DataHandlerConf", uid="def-crt-grenoble-link-handler"
+            )
+            det_q = db.get_dal(
+                class_name="QueueConnectionRule", uid="crt-grenoble-raw-data-rule"
+            )
 
         hostnum = appnum % len(hosts)
         # print(f"Looking up host[{hostnum}] ({hosts[hostnum]})")


### PR DESCRIPTION
This is needed to allow us to add the CRT data types to the `readout_type_scan_test` in the `daqsystemtest` repo.