### PR TITLE
Moved the definition of the find_free_port Python function…

### DIFF
--- a/python/daqconf/set_connectivity_service_port.py
+++ b/python/daqconf/set_connectivity_service_port.py
@@ -1,8 +1,8 @@
 import conffwk
 import confmodel
+from daqconf.utils import find_free_port
 
 import re
-import socket
 
 def set_connectivity_service_port(oksfile, session_name, connsvc_port=0):
     """Script to set the value of the Connectivity Service port in the specified Session of the specified
@@ -24,14 +24,6 @@ def set_connectivity_service_port(oksfile, session_name, connsvc_port=0):
     dal = conffwk.dal.module("dal", schemafiles)
 
     if connsvc_port == 0:
-        def find_free_port():
-            with socket.socket() as s:
-                s.bind(("", 0))
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                port = s.getsockname()[1]
-                s.close()
-                return port
-
         new_port = find_free_port()
     else:
         new_port = connsvc_port

--- a/python/daqconf/utils.py
+++ b/python/daqconf/utils.py
@@ -1,6 +1,7 @@
 import glob
 import logging
 import os
+import socket
 from rich.logging import RichHandler
 
 
@@ -85,3 +86,11 @@ def find_oksincludes(includes:list[str], extra_dirs:list[str] = []):
             return [False, []]
 
     return [True, includefiles]
+
+def find_free_port():
+    with socket.socket() as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        port = s.getsockname()[1]
+        s.close()
+        return port


### PR DESCRIPTION
… from `set_connectivity_service_port.py` to `utils.py` so that it is available for use in other scripts.

## Description

This is part of improving support for the use of random ports in integtests, and it is initially being used to allow multiple simultaneous runs of the `asiolibs` and `crtmodules` integtests to work.

This change is a building block for related changes in `asiolibs` and `crtmodules`.

## Testing Suggestions

Please see the suggestions in the parent Issue, DUNE-DAQ/daq-deliverables#189
