### PR TITLE
Use oks python bindings to reformat schema files

### DIFF
--- a/python/daqconf/oks_format.py
+++ b/python/daqconf/oks_format.py
@@ -1,12 +1,24 @@
 import conffwk
+import oks
 
 def oks_format(input_file) -> None:
-    print(f"Formatting file {input_file}")
-    dal = conffwk.dal.module("generated", "schema/confmodel/dunedaq.schema.xml")
-    oks_kernel = conffwk.Configuration(f"oksconflibs:{input_file}")
+    if ".data.xml" in input_file:
+        print(f"Formatting database file {input_file}")
+        dal = conffwk.dal.module("generated", "schema/confmodel/dunedaq.schema.xml")
+        oks_kernel = conffwk.Configuration(f"oksconflibs:{input_file}")
 
-    testobj = dal.Service("Reformat-test-obj")
-    oks_kernel.update_dal(testobj)
-    oks_kernel.destroy_dal(testobj)
+        testobj = dal.Service("Reformat-test-obj")
+        oks_kernel.update_dal(testobj)
+        oks_kernel.destroy_dal(testobj)
 
-    oks_kernel.commit()
+        oks_kernel.commit()
+    elif ".schema.xml" in input_file:
+        print(f"Formatting schema file {input_file}")
+        
+        oks_kernel = oks.OksKernel()
+        schema = oks_kernel.load_schema(str(input_file))
+        #oks_kernel.save_all_schema()
+        oks_kernel.save_as_schema(str(input_file), schema)
+
+    else:
+        print(f"Don't know how to handle file {input_file}")


### PR DESCRIPTION
## Description

The `oks-format` utility has been available for formatting `*.data.xml` files for quite some time.  It would be great if it could also be used for formatting `*.schema.xml` files.  The changes in this PR add that functionality.

## Testing Suggestions

Without these changes, running `oks-format` on a `*.schema.xml` file produces an error.  With these changes, the schema file is successfully formatted. 

Also, with these changes, running `oks-format` on a file that is not a `*.data.xml` or `*.schema.xml` file will produce a simple message stating that the script doesn't know how to handle the input file, rather than a trace-back.
