### PR TITLE
Added the ability to specify crate and slot numbers for generate_hwmap()…

### DIFF
--- a/python/daqconf/generate_hwmap.py
+++ b/python/daqconf/generate_hwmap.py
@@ -6,7 +6,7 @@ import json
 import sys
 
 def generate_hwmap(oksfile, n_streams, n_apps = 1, det_id = 3, app_host = "localhost",
-                             eth_protocol = "udp", flx_mode = "fix_rate"):
+                   eth_protocol = "udp", flx_mode = "fix_rate", crate_id_offset = 1, slot_id = 0):
 
     schemafiles = [
         "schema/confmodel/dunedaq.schema.xml",
@@ -43,7 +43,7 @@ def generate_hwmap(oksfile, n_streams, n_apps = 1, det_id = 3, app_host = "local
                 geo_dal = dal.GeoId(
                     f"geioId-{source_id}",
                     detector_id=det_id,
-                    crate_id=app+1,
+                    crate_id=app+crate_id_offset,
                     slot_id=stream_no,
                     stream_id=1,
                 )
@@ -51,8 +51,8 @@ def generate_hwmap(oksfile, n_streams, n_apps = 1, det_id = 3, app_host = "local
                 geo_dal = dal.GeoId(
                     f"geioId-{source_id}",
                     detector_id=det_id,
-                    crate_id=app+1,
-                    slot_id=0,
+                    crate_id=app+crate_id_offset,
+                    slot_id=slot_id,
                     stream_id=stream_no,
                 )
             db.update_dal(geo_dal)


### PR DESCRIPTION
…This is useful in cases in which the crate and slot of replay data matters, for example, when generating TPs using a real detector channel map.

## Description

These changes are part of DUNE-DAQ/daqsystemtest#243, and they consist of the addition of the ability to specify a crate_id and slot_id to the `generate_hwmap` code.  This is needed for cases in which we want to have the GeoId (e.g. crate_id and slot_id) in fake-data-replay match what was assigned to the data when it was acquired from the real electronics.

## Testing Suggestions

Please see the instructions listed in DUNE-DAQ/daqsystemtest#243.
