### PR TITLE
Modified the default frame file provided in generate_readout…

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -359,7 +359,7 @@ def generate_readout(
     oksfile,
     include,
     generate_segment,
-    emulated_file_name="asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e",
+    emulated_file_name="asset://?checksum=370df564205290d27cab47e44ae4ca47",
     tpg_enabled=True,
     hosts_to_use=[],
 ):

--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -359,7 +359,7 @@ def generate_readout(
     oksfile,
     include,
     generate_segment,
-    emulated_file_name="asset://?checksum=370df564205290d27cab47e44ae4ca47",
+    emulated_file_name,
     tpg_enabled=True,
     hosts_to_use=[],
 ):


### PR DESCRIPTION
…to reference a more recent binary file.

## Description

DUNE-DAQ/daqsystemtest#245 requests that we update our regression tests, etc. to use recent data-replay files from the _assets_ system.

In this repo, that translated to changing the checksum of the default asset file that is used in integration tests.  The new file is `wib_link_67.bin`, which was recently created by Eric.

*** Please Note that the change that was made in this repo was modified based on a suggestion from Eric.  Instead of updating the default frame_file value, we removed the default value altogether since it effectively is never used.

## Testing Suggestions

There are suggestions in DUNE-DAQ/daqsystemtest#245 for testing all of the asset-file-update changes together.
