### PR TITLE
Set the FragmentAggregator config in generated Readout and FakeData Applications

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -516,6 +516,7 @@ def generate_readout(
     db.update_dal(rohw)
 
     opmon_conf = db.get_dal(class_name="OpMonConf", uid="slow-all-monitoring")
+    fragagg = db.get_dal(class_name="FragmentAggregatorConf", uid="frag-agg-01")
 
     appnum = 0
     nicrec = None
@@ -688,6 +689,7 @@ def generate_readout(
             queue_rules=qrules + [det_q],
             link_handler=linkhandler,
             data_reader=datareader,
+            fragment_aggregator=fragagg,
             opmon_conf=opmon_conf,
             tp_generation_enabled=tpg_enabled,
             ta_generation_enabled=tpg_enabled,
@@ -794,6 +796,7 @@ def generate_fakedata(
     dataRequests = db.get_dal(class_name="Service", uid="dataRequests")
     timeSyncs = db.get_dal(class_name="Service", uid="timeSyncs")
     opmon_conf = db.get_dal(class_name="OpMonConf", uid="slow-all-monitoring")
+    fragagg = db.get_dal(class_name="FragmentAggregatorConf", uid="frag-agg-01")
 
     rule = db.get_dal(
             class_name="NetworkConnectionRule", uid="data-req-readout-net-rule"
@@ -835,6 +838,7 @@ def generate_fakedata(
         exposes_service=[daqapp_control, dataRequests, timeSyncs],
         queue_rules=qrules,
         network_rules=netrules,
+        fragment_aggregator=fragagg,
         opmon_conf=opmon_conf,)
 
         for streamidx in range(n_streams):


### PR DESCRIPTION
# Description

See DUNE-DAQ/dfmodules#453 for details

Include the FragmentAggregatorConf in generated ReadoutApplications and FakeDataApplications.
Without this change, integration tests using the updated appmodel branch will not work.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Correlated Changes

* DUNE-DAQ/daqsystemtest#256
* DUNE-DAQ/appmodel#253
* DUNE-DAQ/dfmodules#455
* DUNE-DAQ/daqconf#609 (this PR)

