### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqconf VERSION 8.7.0)
+project(daqconf VERSION 8.7.1)
 
 find_package(daq-cmake REQUIRED )
 

--- a/python/daqconf/consolidate.py
+++ b/python/daqconf/consolidate.py
@@ -16,7 +16,35 @@ def get_all_includes(db, file):
 
     return list(set(includes))
 
+def consolidate_db(oksfile: str, output_file: str, session_id: Optional[str] = None)->None:
+    """Consolidates a single session
+
+    :param oksfile: OKS file(s) to consolidate
+    :param output_file: File to output consolidated database to 
+    :param session_id: Name of session, defaults to None
+    """    
+    log.info(f"Consolidating database into output database '{output_file}'. Input database: '{oksfile}'.")
+
+    sys.setrecursionlimit(10000)  # for example
+    db, new_db = create_copy_template(oksfile, output_file)
+
+    if session_id is None:
+        log.debug("Consolidating all dals in %s into %s", oksfile, output_file)
+        consolidate_full(db, new_db)
+    else:
+        log.debug("Consolidating all dals in session %s from %s into %s", session_id, oksfile, output_file)
+
+        consolidate_session(db, new_db, session_id)
+
+
 def create_copy_template(oksfile: str, output_file: str)->Tuple[conffwk.Configuration, conffwk.Configuration]:
+    '''
+    Creates a blank oks .data.xml file stored in output_file with all the schema includes of oksfile
+    :param oksfile: OKS file to copy includes from
+    :param output_file: OKS file to copy includes into
+
+    :returns: Tuple of old_db, copied_db
+    '''
     log.debug("Reading database")
     db = conffwk.Configuration("oksconflibs:" + oksfile)
 
@@ -33,25 +61,25 @@ def create_copy_template(oksfile: str, output_file: str)->Tuple[conffwk.Configur
     return db, new_db
 
 
-def consolidate_db(oksfile, output_file, session_id: Optional[str] = None)->None:
-    log.info(f"Consolidating database into output database \'{output_file}\'. Input database: \'{oksfile}\'.")
-
-    sys.setrecursionlimit(10000)  # for example
-    db, new_db = create_copy_template(oksfile, output_file)
-
-    if session_id is None:
-        log.debug("Consolidating all dals in %s into %s", oksfile, output_file)
-        consolidate_full(db, new_db)
-    else:
-        log.debug("Consolidating all dals in session %s from %s into %s", session_id, oksfile, output_file)
-
-        consolidate_session(db, new_db, session_id)
-
 def consolidate_full(db: conffwk.Configuration, new_db: conffwk.Configuration)->None:
+    """Consolidates ALL dal objects in db into new_db
+
+    :param db: A conffwk.Configuration containing objects you want to copy over
+    :param new_db: A conffwk.Configuration you want to copy objects into
+    """    
     dal_list = list(db.get_all_dals().values())
-    copy_dals_to_cfg(db, new_db, dal_list)
+    copy_dals_to_cfg(new_db, dal_list)
 
 def consolidate_session(db: conffwk.Configuration, new_db: conffwk.Configuration, session_id: str)->None:
+    """
+    Consolidates all objects related to the session with id 'session_id' into a single file
+    
+    :param db: A conffwk.Configuration containing objects you want to copy over
+    :param new_db: A conffwk.Configuration you want to copy objects into
+    :param session_id: Name of session
+    """
+
+    # Check session exists and load
     try:
         dal_session = db.get_dal('Session', session_id)
     except Exception as e:
@@ -59,9 +87,12 @@ def consolidate_session(db: conffwk.Configuration, new_db: conffwk.Configuration
         raise e
     
     dal_list = get_relationships(db, dal_session, [])
-    copy_dals_to_cfg(db, new_db, dal_list)
+    copy_dals_to_cfg(new_db, dal_list)
 
 def get_relationships(db: conffwk.Configuration, current_dal, dal_list):
+    '''
+    Recurssively get all objects related to current_dal
+    '''
     dal_list.append(current_dal)
     
     for rel in db.relations(current_dal.className(), all=True):
@@ -78,14 +109,16 @@ def get_relationships(db: conffwk.Configuration, current_dal, dal_list):
     return dal_list
 
 
-def copy_dals_to_cfg(db: conffwk.Configuration, new_db: conffwk.Configuration, dal_list)->None:
+def copy_dals_to_cfg(new_db: conffwk.Configuration, dal_list)->None:
+    '''
+    Copy a list of dals into a configuration
+    '''
     log.debug("Copying %d objects to new db", len(dal_list))
     for dal in dal_list:
         new_db.add_dal(dal)
 
     log.debug("Saving database")
     new_db.commit()
-
     
     
 def copy_configuration(dest_dir : Path, input_files: list):

--- a/python/daqconf/consolidate.py
+++ b/python/daqconf/consolidate.py
@@ -3,6 +3,7 @@ import conffwk
 import sys
 import os
 from logging import getLogger
+from typing import Optional, Tuple
 log = getLogger('daqconf.consolidate')
 
 
@@ -15,10 +16,7 @@ def get_all_includes(db, file):
 
     return list(set(includes))
 
-def consolidate_db(oksfile, output_file):
-    log.info(f"Consolidating database into output database \'{output_file}\'. Input database: \'{oksfile}\'.")
-
-    sys.setrecursionlimit(10000)  # for example
+def create_copy_template(oksfile: str, output_file: str)->Tuple[conffwk.Configuration, conffwk.Configuration]:
     log.debug("Reading database")
     db = conffwk.Configuration("oksconflibs:" + oksfile)
 
@@ -30,22 +28,66 @@ def consolidate_db(oksfile, output_file):
     log.debug("Creating new database")
     new_db = conffwk.Configuration("oksconflibs")
     new_db.create_db(output_file, schemafiles)
-
     new_db.commit()
+    
+    return db, new_db
 
-    log.debug("Reading dal objects from old db")
-    dals = db.get_all_dals()
 
-    log.debug(f"Copying objects to new db")
+def consolidate_db(oksfile, output_file, session_id: Optional[str] = None)->None:
+    log.info(f"Consolidating database into output database \'{output_file}\'. Input database: \'{oksfile}\'.")
 
-    for dal in dals:
-        this_dal = db.get_dal(dals[dal].className(), dals[dal].id)
-        new_db.add_dal(this_dal)
+    sys.setrecursionlimit(10000)  # for example
+    db, new_db = create_copy_template(oksfile, output_file)
+
+    if session_id is None:
+        log.debug("Consolidating all dals in %s into %s", oksfile, output_file)
+        consolidate_full(db, new_db)
+    else:
+        log.debug("Consolidating all dals in session %s from %s into %s", session_id, oksfile, output_file)
+
+        consolidate_session(db, new_db, session_id)
+
+def consolidate_full(db: conffwk.Configuration, new_db: conffwk.Configuration)->None:
+    dal_list = list(db.get_all_dals().values())
+    copy_dals_to_cfg(db, new_db, dal_list)
+
+def consolidate_session(db: conffwk.Configuration, new_db: conffwk.Configuration, session_id: str)->None:
+    try:
+        dal_session = db.get_dal('Session', session_id)
+    except Exception as e:
+        log.exception(e)
+        raise e
+    
+    dal_list = get_relationships(db, dal_session, [])
+    copy_dals_to_cfg(db, new_db, dal_list)
+
+def get_relationships(db: conffwk.Configuration, current_dal, dal_list):
+    dal_list.append(current_dal)
+    
+    for rel in db.relations(current_dal.className(), all=True):
+        rel_obj = getattr(current_dal, rel, None)
+        if rel_obj is None:
+            continue
+        
+        if not isinstance(rel_obj, list):
+            rel_obj = [rel_obj]
+        
+        for rel_obj in rel_obj:
+            dal_list = get_relationships(db, rel_obj, dal_list)
+        
+    return dal_list
+
+
+def copy_dals_to_cfg(db: conffwk.Configuration, new_db: conffwk.Configuration, dal_list)->None:
+    log.debug("Copying %d objects to new db", len(dal_list))
+    for dal in dal_list:
+        new_db.add_dal(dal)
 
     log.debug("Saving database")
     new_db.commit()
 
-
+    
+    
 def copy_configuration(dest_dir : Path, input_files: list):
     if len(input_files) == 0:
         return []
@@ -72,9 +114,7 @@ def copy_configuration(dest_dir : Path, input_files: list):
         dals = db.get_all_dals()
 
         for dal in dals:
-
             db.get_dal(dals[dal].className(), dals[dal].id)
-
             new_db.add_dal(dals[dal])
 
         new_db.commit()

--- a/scripts/consolidate
+++ b/scripts/consolidate
@@ -7,9 +7,10 @@ from daqconf.utils import log_levels, setup_logging
 @click.option('--oksfile', '-i', help='Input database to read')
 @click.option('--log-level', '-l', help='Log level', default='INFO', type=click.Choice(log_levels, case_sensitive=False))
 @click.argument('output_file')
-def consolidate(oksfile, output_file, log_level):
+@click.option('--session', '-s', help='Session ID', default=None)
+def consolidate(oksfile, output_file, log_level, session):
     setup_logging(log_level)
-    consolidate_db(oksfile, output_file)
+    consolidate_db(oksfile, output_file, session)
 
 if __name__ == '__main__':
     consolidate()


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 

# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

