### PR TITLE
patch: fix regex in daqconf inspector to use r-string

### DIFF
--- a/scripts/daqconf_inspector
+++ b/scripts/daqconf_inspector
@@ -560,7 +560,7 @@ def show_object_tree(obj, uid, show_attrs, focus_path, level, session_name, show
 
     
     focus_path = focus_path.split('.') if focus_path is not None else []
-    re_index = re.compile('([\w-]*)(\[([\w-]*)\])?')
+    re_index = re.compile(r'([\w-]*)(\[([\w-]*)\])?')
     path = []
     for p in focus_path:
         m = re_index.match(p)
@@ -885,7 +885,7 @@ def show_smartapp_mods(obj, session_id, app_id, show_attrs, level, focus_path):
     drr = DalRichRenderer(cfg)
 
     focus_path = focus_path.split('.') if focus_path is not None else []
-    re_index = re.compile('([\w-]*)(\[([\w-]*)\])?')
+    re_index = re.compile(r'([\w-]*)(\[([\w-]*)\])?')
     path = []
     for p in focus_path:
         m = re_index.match(p)


### PR DESCRIPTION
# Description
Regex in daqconf-inspector was not using raw-strings

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

