### PR TITLE
CRT readers communicate with socket writers via IOM

### DIFF
--- a/apps/GraphBuilder.cpp
+++ b/apps/GraphBuilder.cpp
@@ -25,9 +25,8 @@
 
 #include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataReaderModule.hpp"
-#include "appmodel/CRTBernReaderModule.hpp"
-#include "appmodel/CRTGrenobleReaderModule.hpp"
 #include "appmodel/DataMoveCallbackConf.hpp"
+#include "appmodel/SocketDataWriterModule.hpp"
 
 #include "conffwk/Configuration.hpp"
 #include "conffwk/Schema.hpp"
@@ -474,17 +473,14 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
         // Look for DataMoveCallbackConfs
         auto datareader = module->cast<dunedaq::appmodel::DataReaderModule>();
         auto datahandler = module->cast<dunedaq::appmodel::DataHandlerModule>();
-        
+        auto socketwriter = module->cast<dunedaq::appmodel::SocketDataWriterModule>();
+
         if (datareader != nullptr) {
-          auto crtdatareader = module->cast<dunedaq::appmodel::CRTBernReaderModule>() != nullptr ||
-                               module->cast<dunedaq::appmodel::CRTGrenobleReaderModule>() != nullptr;
-          if (!crtdatareader) { // Don't check raw data callbacks for CRT readers
-            for (auto& out : datareader->get_raw_data_callbacks()) {
-              const std::string key = out->config_object().UID() + "@" + out->config_object().class_name();
-              if (std::ranges::find(allowed_conns, out->config_object().class_name()) != allowed_conns.end()) {
-                m_outgoing_connections[key].push_back(object.UID());
-                m_outgoing_connections[key].push_back(module->UID());
-              }
+          for (auto& out : datareader->get_raw_data_callbacks()) {
+            const std::string key = out->config_object().UID() + "@" + out->config_object().class_name();
+            if (std::ranges::find(allowed_conns, out->config_object().class_name()) != allowed_conns.end()) {
+              m_outgoing_connections[key].push_back(object.UID());
+              m_outgoing_connections[key].push_back(module->UID());
             }
           }
         }
@@ -493,6 +489,15 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
           if (in != nullptr) {
             const std::string key = in->config_object().UID() + "@" + in->config_object().class_name();
 
+            if (std::ranges::find(allowed_conns, in->config_object().class_name()) != allowed_conns.end()) {
+              m_incoming_connections[key].push_back(object.UID());
+              m_incoming_connections[key].push_back(module->UID());
+            }
+          }
+        }
+        if (socketwriter != nullptr) {
+          for (auto& in : socketwriter->get_raw_data_callbacks()) {
+            const std::string key = in->config_object().UID() + "@" + in->config_object().class_name();
             if (std::ranges::find(allowed_conns, in->config_object().class_name()) != allowed_conns.end()) {
               m_incoming_connections[key].push_back(object.UID());
               m_incoming_connections[key].push_back(module->UID());

--- a/apps/GraphBuilder.cpp
+++ b/apps/GraphBuilder.cpp
@@ -25,8 +25,9 @@
 
 #include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataReaderModule.hpp"
+#include "appmodel/CRTBernReaderModule.hpp"
+#include "appmodel/CRTGrenobleReaderModule.hpp"
 #include "appmodel/DataMoveCallbackConf.hpp"
-#include "appmodel/SocketDataWriterModule.hpp"
 
 #include "conffwk/Configuration.hpp"
 #include "conffwk/Schema.hpp"
@@ -473,30 +474,22 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
         // Look for DataMoveCallbackConfs
         auto datareader = module->cast<dunedaq::appmodel::DataReaderModule>();
         auto datahandler = module->cast<dunedaq::appmodel::DataHandlerModule>();
-        auto socketwriter = module->cast<dunedaq::appmodel::SocketDataWriterModule>();
-
+        
         if (datareader != nullptr) {
-          for (auto& out : datareader->get_raw_data_callbacks()) {
-            const std::string key = out->config_object().UID() + "@" + out->config_object().class_name();
-            if (std::ranges::find(allowed_conns, out->config_object().class_name()) != allowed_conns.end()) {
-              m_outgoing_connections[key].push_back(object.UID());
-              m_outgoing_connections[key].push_back(module->UID());
+          auto crtdatareader = module->cast<dunedaq::appmodel::CRTBernReaderModule>() != nullptr ||
+                               module->cast<dunedaq::appmodel::CRTGrenobleReaderModule>() != nullptr;
+          if (!crtdatareader) { // Don't check raw data callbacks for CRT readers
+            for (auto& out : datareader->get_raw_data_callbacks()) {
+              const std::string key = out->config_object().UID() + "@" + out->config_object().class_name();
+              if (std::ranges::find(allowed_conns, out->config_object().class_name()) != allowed_conns.end()) {
+                m_outgoing_connections[key].push_back(object.UID());
+                m_outgoing_connections[key].push_back(module->UID());
+              }
             }
           }
         }
         if (datahandler != nullptr) {
           auto in = datahandler->get_raw_data_callback();
-          if (in != nullptr) {
-            const std::string key = in->config_object().UID() + "@" + in->config_object().class_name();
-
-            if (std::ranges::find(allowed_conns, in->config_object().class_name()) != allowed_conns.end()) {
-              m_incoming_connections[key].push_back(object.UID());
-              m_incoming_connections[key].push_back(module->UID());
-            }
-          }
-        }
-        if (socketwriter != nullptr) {
-          auto in = socketwriter->get_raw_data_callback();
           if (in != nullptr) {
             const std::string key = in->config_object().UID() + "@" + in->config_object().class_name();
 

--- a/apps/GraphBuilder.cpp
+++ b/apps/GraphBuilder.cpp
@@ -26,7 +26,6 @@
 #include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataReaderModule.hpp"
 #include "appmodel/DataMoveCallbackConf.hpp"
-#include "appmodel/SocketDataWriterModule.hpp"
 
 #include "conffwk/Configuration.hpp"
 #include "conffwk/Schema.hpp"
@@ -423,7 +422,9 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
     if (daqapp) {
       auto local_session = const_cast<dunedaq::confmodel::Session*>( // NOLINT
         local_database->get<dunedaq::confmodel::Session>(m_session_name));
-      daqapp->generate_modules(local_session);
+
+      auto helper = std::make_shared<dunedaq::appmodel::ConfigurationHelper>(local_session);
+      daqapp->generate_modules(helper);        
       auto modules = daqapp->get_modules();
 
       std::vector<std::string> allowed_conns{};
@@ -473,7 +474,6 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
         // Look for DataMoveCallbackConfs
         auto datareader = module->cast<dunedaq::appmodel::DataReaderModule>();
         auto datahandler = module->cast<dunedaq::appmodel::DataHandlerModule>();
-        auto socketwriter = module->cast<dunedaq::appmodel::SocketDataWriterModule>();
 
         if (datareader != nullptr) {
           for (auto& out : datareader->get_raw_data_callbacks()) {
@@ -489,15 +489,6 @@ GraphBuilder::find_objects_and_connections(const ConfigObject& object)
           if (in != nullptr) {
             const std::string key = in->config_object().UID() + "@" + in->config_object().class_name();
 
-            if (std::ranges::find(allowed_conns, in->config_object().class_name()) != allowed_conns.end()) {
-              m_incoming_connections[key].push_back(object.UID());
-              m_incoming_connections[key].push_back(module->UID());
-            }
-          }
-        }
-        if (socketwriter != nullptr) {
-          for (auto& in : socketwriter->get_raw_data_callbacks()) {
-            const std::string key = in->config_object().UID() + "@" + in->config_object().class_name();
             if (std::ranges::find(allowed_conns, in->config_object().class_name()) != allowed_conns.end()) {
               m_incoming_connections[key].push_back(object.UID());
               m_incoming_connections[key].push_back(module->UID());

--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -577,9 +577,17 @@ def generate_readout(
             linkhandler = db.get_dal(
                 class_name="DataHandlerConf", uid="def-crt-bern-link-handler"
             )
+            # Not used, but needed for ReadoutApplication
+            cb_desc = db.get_dal(
+                class_name="DataMoveCallbackDescriptor", uid="crt-bern-raw-input"
+            )
         elif det_id == 13:
             linkhandler = db.get_dal(
                 class_name="DataHandlerConf", uid="def-crt-grenoble-link-handler"
+            )
+            # Not used, but needed for ReadoutApplication
+            cb_desc = db.get_dal(
+                class_name="DataMoveCallbackDescriptor", uid="crt-grenoble-raw-input"
             )
 
         hostnum = appnum % len(hosts)
@@ -674,7 +682,8 @@ def generate_readout(
             if nicrec == None:
                 try:
                     snb_files = db.get_dal(
-                        class_name="SNBFileSourceParameters", uid=f"snb-files-{connection.id}"
+                        class_name="SNBFileSourceParameters",
+                        uid=f"snb-files-{connection.id}",
                     )
                     snb_files.data_files = [resolve_asset_file(emulated_file_name)]
                     db.update_dal(snb_files)
@@ -783,7 +792,9 @@ def generate_readout(
     return
 
 
-def generate_fakedata(oksfile, include, generate_segment, n_streams, n_apps, det_id, fragment_type=None):
+def generate_fakedata(
+    oksfile, include, generate_segment, n_streams, n_apps, det_id, fragment_type=None
+):
     """Simple script to create an OKS configuration file for a FakeDataProd-based readout segment.
 
       The file will automatically include the relevant schema files and
@@ -883,14 +894,16 @@ def generate_fakedata(oksfile, include, generate_segment, n_streams, n_apps, det
 
     for appidx in range(n_apps):
 
-        fakeapp = dal.FakeDataApplication(f"fakedata_{appidx}",
-        runs_on=host,
-        application_name="daq_application",
-        exposes_service=[daqapp_control, dataRequests, timeSyncs],
-        queue_rules=qrules,
-        network_rules=netrules,
-        fragment_aggregator=fragagg,
-        opmon_conf=opmon_conf,)
+        fakeapp = dal.FakeDataApplication(
+            f"fakedata_{appidx}",
+            runs_on=host,
+            application_name="daq_application",
+            exposes_service=[daqapp_control, dataRequests, timeSyncs],
+            queue_rules=qrules,
+            network_rules=netrules,
+            fragment_aggregator=fragagg,
+            opmon_conf=opmon_conf,
+        )
 
         for streamidx in range(n_streams):
             stream = dal.FakeDataProdConf(
@@ -1033,7 +1046,9 @@ def generate_trigger(
             class_name="FixedTimeTCMakerModuleConf",
             uid="ft-trig-conf",
         )
-        print(f"FixedTimeTCMakerModule has been configured, disabling random triggers and HSI")
+        print(
+            f"FixedTimeTCMakerModule has been configured, disabling random triggers and HSI"
+        )
         tc_confs = [fixedtime_tc_generator]
     except:
         pass  # No FixedTimeTCMaker

--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -577,15 +577,9 @@ def generate_readout(
             linkhandler = db.get_dal(
                 class_name="DataHandlerConf", uid="def-crt-bern-link-handler"
             )
-            cb_desc = db.get_dal(
-                class_name="DataMoveCallbackDescriptor", uid="crt-bern-raw-input"
-            )
         elif det_id == 13:
             linkhandler = db.get_dal(
                 class_name="DataHandlerConf", uid="def-crt-grenoble-link-handler"
-            )
-            cb_desc = db.get_dal(
-                class_name="DataMoveCallbackDescriptor", uid="crt-grenoble-raw-input"
             )
 
         hostnum = appnum % len(hosts)


### PR DESCRIPTION
- For each connection, there are, per DataSender:
  - 1 dedicated D2D connection (with this sender only)
  - 1 CRT frame builder
  - 1 SocketWriter
  - 1 IOM
- CRT readers communicate with socket writers via IOM.
- Socket readers communicate with DHLs via callbacks.

To try out:
- `create_config_plot -f config/daqsystemtest/example-configs.data.xml -r crt-data-source-01 -s local-socket-1x1-config`
<img width="1154" height="701" alt="image" src="https://github.com/user-attachments/assets/12d6bcf9-4a11-4fc1-8b76-928bfc4135da" />

- `create_config_plot -f config/daqsystemtest/example-configs.data.xml -r socket-ru-01 -s local-socket-1x1-config`
<img width="1625" height="646" alt="image" src="https://github.com/user-attachments/assets/34fd5f36-c806-4caf-9cda-9d7b00f33e89" />

[appmodel PR](https://github.com/DUNE-DAQ/appmodel/pull/278) dte/crt_topology_change
[daqsystemtest PR](https://github.com/DUNE-DAQ/daqsystemtest/pull/303) dte/crt_topology_change
[crtmodules PR](https://github.com/DUNE-DAQ/crtmodules/pull/32) dte/crt_topology_change
[asiolibs PR](https://github.com/DUNE-DAQ/asiolibs/pull/37) dte/crt_topology_change
[daqconf PR](https://github.com/DUNE-DAQ/daqconf/pull/622) dte/crt_cb_update
[datahandlinglibs PR](https://github.com/DUNE-DAQ/datahandlinglibs/pull/130) dte/cb_acquire
[fdreadoutmodules PR](https://github.com/DUNE-DAQ/fdreadoutmodules/pull/64) dte/crt_rates