### PR TITLE
Updated the root-controller configuration in generate_session so that…

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -1159,13 +1159,16 @@ def generate_session(
         db.update_dal(host)
         hosts.append("vlocalhost")
 
+    opmon_conf = db.get_dal(class_name="OpMonConf", uid="slow-all-monitoring")
+
     fsm = db.get_dal(class_name="FSMconfiguration", uid="fsmConf-test")
-    rccontroller_control = db.get_dal(class_name="Service", uid="rccontroller_control")
+    rccontroller_control = db.get_dal(class_name="Service", uid="root-rccontroller_control")
     controller = dal.RCApplication(
         "root-controller",
         application_name="drunc-controller",
         runs_on=host,
         fsm=fsm,
+        opmon_conf=opmon_conf,
         exposes_service=[rccontroller_control],
     )
     db.update_dal(controller)


### PR DESCRIPTION
… it uses the latest rccontroller service and has a specified opmon_conf.

# Description

This change is for v5.7.0...

While working on changes to integration test infrastructure, I noticed that the `pytest` framework has been capturing (and not displaying to the user) a warning message from the configuration-generation step in the integration tests.

That message was the following:

```
WARNING  root:Configuration.py:510 Ignoring error in setting <ConfigObject 'root-controller@RCApplication'>: Error setting value of variable 'opmon_conf' in <ConfigObject 'root-controller@RCApplication'> to 'None': failed to set value relationship "opmon_conf" of object "root-controller@RCApplication"
```

I believe that the cause for this warning message is that the configuration-generation for the root-controller in the `generation_session` function in `generate.py` needed to be updated to match the current state of other parts of the code.

Specifically, it needed to specify the `opmon_conf` for the root-controller and it needed to use the latest rccontroller UID.  

This PR has these changes, and these changes avoid the warning message.  

I believe that without these fixes, some or all of the default root-controller configuration that is provided in `daqsystemtest/config/daqsystemtest/ccm.data.xml` was not being over-written with the update provided in `generate_session`.

Here are suggested instructions for demonstrating the fix:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260403_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/daqconf.git -b develop
cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b develop
cd ..

sed -i 's/run_dunerc.completed_process.returncode == 0/run_dunerc.completed_process.returncode == 99/' sourcecode/daqsystemtest/integtest/minimal_system_quick_test.py

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k minimal

echo ""
echo -e "\U1F535 \U2705 Note that there is an extra complaint in the failure messages about a problem creating/updating the root-controller configuration. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/daqconf
git checkout kbiery/generate_rootcontroller_fix
cd ../../

dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k minimal

echo ""
echo -e "\U1F535 \U2705 Note that the extra problem report is now gone. \U2705 \U1F535"
echo ""
echo ""
```

A follow-up note:  I have draft changes to the integration test infrastructure to display warnings like this to users (so we don't go a long time without noticing problems like this one).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

