### PR TITLE
Don't consider it an error if CONNECTION_PORT Variable is not set

### DIFF
--- a/python/daqconf/set_connectivity_service_port.py
+++ b/python/daqconf/set_connectivity_service_port.py
@@ -56,12 +56,6 @@ def set_connectivity_service_port(oksfile, session_name, connsvc_port=0):
             if found_var:
                 break
 
-        if not found_var:
-            print("Error: Could not find a 'CONNECTION_PORT' variable in the session's environment.")
-            return 0
-    else:
-        print("Error: Session has no 'environment' configured. Cannot update CONNECTION_PORT variable.")
-        return 0
 
     db.commit()
     print(f"Successfully configured connectivity service port for session '{session_name}'.")


### PR DESCRIPTION
# Description

It seems that this variable is ignored everywhere and it requires a double definition. It should be removed


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

