### PR TITLE
Added get_session_env_var scripts

### DIFF
--- a/python/daqconf/get_session_env_var.py
+++ b/python/daqconf/get_session_env_var.py
@@ -1,0 +1,45 @@
+import conffwk
+import confmodel_dal
+import sys
+
+def get_session_env_var(oksfile, session_name, requested_env_var_name):
+    """Script to get the value of an environment variable in the specified Session of the
+    specified OKS database file"""
+    db = conffwk.Configuration("oksconflibs:" + oksfile)
+    if session_name == "":
+        print(f"Error: the session name needs to be specified", file=sys.stderr)
+        return
+    else:
+        try:
+            session = db.get_dal("Session", session_name)
+        except:
+            print(f"Error: could not find Session \"{session_name}\" in file \"{oksfile}\"", file=sys.stderr)
+            return
+
+    schemafiles = [
+        "schema/confmodel/dunedaq.schema.xml"
+    ]
+    dal = conffwk.dal.module("dal", schemafiles)
+
+    # Check if the requested env var is defined for the specified OKS Session
+    existing_env_var = None
+    for entry in session.environment:
+        if isinstance(entry, dal.VariableSet):
+            for subentry in entry.contains:
+                if subentry.name == requested_env_var_name:
+                    existing_env_var = subentry
+                    break
+        else:
+            if entry.name == requested_env_var_name:
+                existing_env_var = entry
+
+        if existing_env_var is not None:
+            break
+
+    # Return the value, or complain and return None if the env var was not found
+    if existing_env_var is None:
+        print(f"Error: could not find env var \"{requested_env_var_name}\" in Session \"{session_name}\"", file=sys.stderr)
+        return
+    else:
+        value = existing_env_var.value
+        return value

--- a/python/daqconf/set_session_env_var.py
+++ b/python/daqconf/set_session_env_var.py
@@ -1,18 +1,19 @@
 import conffwk
 import confmodel_dal
+import sys
 
 def set_session_env_var(oksfile, session_name, requested_env_var_name, requested_env_var_value, overwrite=True):
     """Script to set the value of an environment variable in the specified Session of the
     specified OKS database file"""
     db = conffwk.Configuration("oksconflibs:" + oksfile)
     if session_name == "":
-        print(f"Error: the session name needs to be specified")
+        print(f"Error: the session name needs to be specified", file=sys.stderr)
         return
     else:
         try:
             session = db.get_dal("Session", session_name)
         except:
-            print(f"Error could not find Session {session_name} in file {oksfile}")
+            print(f"Error: could not find Session \"{session_name}\" in file \"{oksfile}\"", file=sys.stderr)
             return
 
     schemafiles = [
@@ -27,12 +28,10 @@ def set_session_env_var(oksfile, session_name, requested_env_var_name, requested
             for subentry in entry.contains:
                 if subentry.name == requested_env_var_name:
                     existing_env_var = subentry
-                    existing_env_var.value = requested_env_var_value
                     break
         else:
             if entry.name == requested_env_var_name:
                 existing_env_var = entry
-                existing_env_var.value = requested_env_var_value
 
         if existing_env_var is not None:
             break
@@ -43,6 +42,7 @@ def set_session_env_var(oksfile, session_name, requested_env_var_name, requested
 
     # if we found an existing env var, update the DB with the new value
     if existing_env_var is not None:
+        existing_env_var.value = requested_env_var_value
         db.update_dal(existing_env_var)
 
     # otherwise, create a new env var and assign it to the OKS Session

--- a/scripts/daqconf_get_session_env_var
+++ b/scripts/daqconf_get_session_env_var
@@ -1,0 +1,17 @@
+#!/bin/env python3
+import click
+from daqconf.get_session_env_var import get_session_env_var
+
+@click.command()
+@click.argument('oks_session_name')
+@click.argument('oksfile')
+@click.argument('env_var_name', required=True, nargs=1)
+def daqconf_get_session_env_var(oksfile, oks_session_name, env_var_name):
+  """Script to get the value of an environment variable in the specified Session of the
+  specified OKS database file. If the env var does not exist, '<None>' is returned."""
+  value = get_session_env_var(oksfile, oks_session_name, env_var_name)
+  if value:
+    print(value)
+
+if __name__ == '__main__':
+  daqconf_get_session_env_var()


### PR DESCRIPTION
# Description

We already have a pair of scripts to _set_ a environment variable in an OKS session environment, and this PR adds a pair of scripts to _get_ the value of an existing env var (from an OKS session).  The "get" functionality will be useful as part of setting TRACE levels from integration tests.

Here are suggested steps for testing the new script:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260714_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/get_sev_script
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop

cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

daqconf_get_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE

echo ""
echo -e "\U1F535 \U2705 Note that an existing value for TRACE_FILE was not found. \U2705 \U1F535"
echo ""
echo ""
sleep 3

echo ""
echo -e "\U1F535 \U2705 Setting the value of the env var to \"ABC\". \U2705 \U1F535"
echo ""
echo ""

daqconf_set_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE "ABC"

echo ""
echo -e "\U1F535 \U2705 Reading back the value of the env var. \U2705 \U1F535"
echo ""
echo ""

daqconf_get_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE
sleep 3

echo ""
echo -e "\U1F535 \U2705 Setting the value to \"DEF\". \U2705 \U1F535"
echo ""
echo ""

daqconf_set_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE "DEF"

echo ""
echo -e "\U1F535 \U2705 Reading back the value of the env var. \U2705 \U1F535"
echo ""
echo ""

daqconf_get_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE
sleep 3

echo ""
echo -e "\U1F535 \U2705 Setting the value to \"/tmp/pytest-of-${USER}/pytest-current/integtest-dunedaq.trace\". \U2705 \U1F535"
echo ""
echo ""

daqconf_set_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE "/tmp/pytest-of-${USER}/pytest-current/integtest-dunedaq.trace"

echo ""
echo -e "\U1F535 \U2705 Reading back the value of the env var. \U2705 \U1F535"
echo ""
echo ""

daqconf_get_session_env_var local-1x1-config config/daqsystemtest/example-configs.data.xml TRACE_FILE
```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

