### PR TITLE
Added 'quiet' flag to get_session_env_var

### DIFF
--- a/python/daqconf/get_session_env_var.py
+++ b/python/daqconf/get_session_env_var.py
@@ -3,7 +3,7 @@ import confmodel_dal
 import sys
 
 def get_session_env_var(
-        oksfile: str, session_name: str, requested_env_var_name: str, quiet: bool = False
+    oksfile: str, session_name: str, requested_env_var_name: str, quiet: bool = False
 ) -> str | None:
     """Script to get the value of an environment variable in the specified Session of the
     specified OKS database file"""

--- a/python/daqconf/get_session_env_var.py
+++ b/python/daqconf/get_session_env_var.py
@@ -2,18 +2,20 @@ import conffwk
 import confmodel_dal
 import sys
 
-def get_session_env_var(oksfile, session_name, requested_env_var_name):
+def get_session_env_var(oksfile, session_name, requested_env_var_name, quiet=False):
     """Script to get the value of an environment variable in the specified Session of the
     specified OKS database file"""
     db = conffwk.Configuration("oksconflibs:" + oksfile)
     if session_name == "":
-        print(f"Error: the session name needs to be specified", file=sys.stderr)
+        if not quiet:
+            print(f"Error: the session name needs to be specified", file=sys.stderr)
         return
     else:
         try:
             session = db.get_dal("Session", session_name)
         except:
-            print(f"Error: could not find Session \"{session_name}\" in file \"{oksfile}\"", file=sys.stderr)
+            if not quiet:
+                print(f"Error: could not find Session \"{session_name}\" in file \"{oksfile}\"", file=sys.stderr)
             return
 
     schemafiles = [
@@ -38,7 +40,8 @@ def get_session_env_var(oksfile, session_name, requested_env_var_name):
 
     # Return the value, or complain and return None if the env var was not found
     if existing_env_var is None:
-        print(f"Error: could not find env var \"{requested_env_var_name}\" in Session \"{session_name}\"", file=sys.stderr)
+        if not quiet:
+            print(f"Error: could not find env var \"{requested_env_var_name}\" in Session \"{session_name}\"", file=sys.stderr)
         return
     else:
         value = existing_env_var.value

--- a/scripts/daqconf_get_session_env_var
+++ b/scripts/daqconf_get_session_env_var
@@ -6,10 +6,11 @@ from daqconf.get_session_env_var import get_session_env_var
 @click.argument('oks_session_name')
 @click.argument('oksfile')
 @click.argument('env_var_name', required=True, nargs=1)
-def daqconf_get_session_env_var(oksfile, oks_session_name, env_var_name):
+@click.argument('quiet', required=False, nargs=1, default=False)
+def daqconf_get_session_env_var(oksfile, oks_session_name, env_var_name, quiet):
   """Script to get the value of an environment variable in the specified Session of the
   specified OKS database file. If the env var does not exist, '<None>' is returned."""
-  value = get_session_env_var(oksfile, oks_session_name, env_var_name)
+  value = get_session_env_var(oksfile, oks_session_name, env_var_name, quiet)
   if value:
     print(value)
 


### PR DESCRIPTION
# Description

There are situations in which it would be nice to have the `get_session_env_var` script run silently.  This PR has the introduction of a `quiet` flag that supports that.

These changes are needed for DUNE-DAQ/integrationtest#166, and that Pull Request has suggestions for testing.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
