### PR TITLE
Removed the disable_connectivity_service argument in the generate_session function

### DIFF
--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -1229,7 +1229,10 @@ def generate_session(
         opmon_uri=opmon_svc,
     )
 
-    # 13-Aug-
+    # 13-Aug-2026, KAB & ELF: removed the conditional execution of the following
+    # few lines based on the 'disable_connectivity_service' function argument.
+    # We believe that the ConnSvc config should always be added to the OKS Session
+    # when we generate a DAQ configuration with this function.
     conn_svc_cfg = db.get_dal(
         class_name="ConnectivityService", uid="local-connectivity-service-config"
     )

--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -1229,6 +1229,7 @@ def generate_session(
         opmon_uri=opmon_svc,
     )
 
+    # 13-Aug-
     conn_svc_cfg = db.get_dal(
         class_name="ConnectivityService", uid="local-connectivity-service-config"
     )

--- a/python/daqconf/generate.py
+++ b/python/daqconf/generate.py
@@ -1133,7 +1133,6 @@ def generate_session(
     session_name: str,
     op_env: str,
     connectivity_service_is_infrastructure_app: bool = True,
-    disable_connectivity_service: bool = False,
 ) -> None:
     """Simple script to create an OKS configuration file for a session.
 
@@ -1230,11 +1229,10 @@ def generate_session(
         opmon_uri=opmon_svc,
     )
 
-    if not disable_connectivity_service:
-        conn_svc_cfg = db.get_dal(
-            class_name="ConnectivityService", uid="local-connectivity-service-config"
-        )
-        sessiondal.connectivity_service = conn_svc_cfg
+    conn_svc_cfg = db.get_dal(
+        class_name="ConnectivityService", uid="local-connectivity-service-config"
+    )
+    sessiondal.connectivity_service = conn_svc_cfg
 
     db.update_dal(sessiondal)
 


### PR DESCRIPTION
# Description

Prompted by questions from @PawelPlesniak about the use of the `--no-integtest-connsvc` option in our integration testing, I found that this option was not interacting with other parts of the system in the way that I expected.

Taking a step back, I'm not sure that we remember how the `--no-integtest-connsvc` option (and its previous name of `--disable-connectivity-service`) was intended to be used.

So, we would like to propose/assert an updated statement of how it should be used and move forward with that.  The proposal is the following:

- the purpose of the custom `pytest` `--no-integtest-connsvc` option is to tell the integration test infrastructure "don't start the ConnSvc either by drunc or by the intg infrastructure" so that the user can run it by hand

Unfortunately, existing code in this repo does not support that model, and this PR fixes that.

The change in this repo is to remove the `disable_connectivity_service` argument from the `generate_session` function because we now believe that we should always include the ConnectivityService in the OKS session when we generate a DAQ configuration.

This PR is correlated with DUNE-DAQ/integrationtest#169.

Here are suggested instructions for testing these changes.  These instructions demonstrate the starting of the `ConnectivityService` by hand and running the `minimal_system_quick_test` with the `--no-integtest_connsvc` option **_and_** seeing that work.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260813_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/noconnsvc_fix
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop

cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/noconnsvc_fix
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k min

echo ""
echo -e "\U1F535 \U2705 Note that the MSQT worked fine when run normally. \U2705 \U1F535"
echo ""
echo ""
sleep 3

gunicorn -b 0.0.0.0:12345 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 connectivityserver.connectionflask:app &

echo ""
echo -e "\U1F535 \U2705 Started the ConnectivityService in the background... \U2705 \U1F535"
echo ""
echo ""
sleep 3

sed -i 's/#conf_dict.connsvc_port/conf_dict.connsvc_port/' sourcecode/daqsystemtest/integtest/minimal_system_quick_test.py
dbt-build -j 12
dbt-workarea-env

echo ""
echo -e "\U1F535 \U2705 Locally modified the MSQT to use a pre-defined port for the ConnSvc.... \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -k min --pytest-options "--no-integtest-connsvc"

echo ""
echo -e "\U1F535 \U2705 Note that the MSQT worked fine with '--no-integtest-connsvc' when we have the ConnectivityService running. \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -k small --pytest-options "--no-integtest-connsvc"

echo ""
echo -e "\U1F535 \U2705 Note that the SFQT did *not* work fine with '--no-integtest-connsvc' even though we have \U2705 \U1F535"
echo -e "\U1F535 \U2705 the ConnectivityService running because we didn't tell it about the special port number. \U2705 \U1F535"
echo ""
echo ""
sleep 3

killall -u ${USER} gunicorn

echo ""
echo -e "\U1F535 \U2705 Killed the ConnectivityService that we started earlier... \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -k example --pytest-options "--no-integtest-connsvc"

echo ""
echo -e "\U1F535 \U2705 Note that the example_system_test worked fine with '--no-integtest-connsvc' \U2705 \U1F535"
echo -e "\U1F535 \U2705 because integtests that use pre-defined DAQ configs are not affected by that option. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
